### PR TITLE
fix: prevent duplicate listener clash on port 12001 and schema validation

### DIFF
--- a/config/envoy.template.yaml
+++ b/config/envoy.template.yaml
@@ -457,6 +457,12 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
+    {# Skip default egress_traffic_llm listener if user already defined a listener on port 12001 #}
+    {% set user_listener_ports = [] %}
+    {% for listener in listeners %}
+      {% set _ = user_listener_ports.append(listener.port) %}
+    {% endfor %}
+    {% if 12001 not in user_listener_ports %}
     - name: egress_traffic_llm
       address:
         socket_address:
@@ -591,6 +597,7 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    {% endif %}
 
   clusters:
 

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -172,14 +172,7 @@ properties:
           type: string
         provider_interface:
           type: string
-          enum:
-            - arch
-            - claude
-            - deepseek
-            - groq
-            - mistral
-            - openai
-            - gemini
+          description: "The provider interface/name. For supported providers (openai, anthropic, gemini, etc.), specify as part of model name (e.g., 'openai/gpt-4'). For custom providers, provide the interface name here."
         routing_preferences:
           type: array
           items:
@@ -219,14 +212,7 @@ properties:
           type: string
         provider_interface:
           type: string
-          enum:
-            - arch
-            - claude
-            - deepseek
-            - groq
-            - mistral
-            - openai
-            - gemini
+          description: "The provider interface/name. For supported providers (openai, anthropic, gemini, etc.), specify as part of model name (e.g., 'openai/gpt-4'). For custom providers, provide the interface name here."
         routing_preferences:
           type: array
           items:


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs found during deployment of Plano v0.3.0:

### 1. Duplicate Listener Bug (port 12001 conflict)

**Problem:** The internal Python config generator creates a default `egress_traffic_llm` listener on port 12001 in the Envoy configuration template. When users define their own listener on port 12001 in their `config.yaml`, this causes Envoy to crash due to duplicate listeners on the same port.

**Solution:** Modified `config/envoy.template.yaml` to add a conditional check that skips rendering the default `egress_traffic_llm` listener if the user has already defined a listener on port 12001.

### 2. Config Validation Mismatch

**Problem:** The JSON schema in `plano_config_schema.yaml` had a restrictive `enum` constraint for the `provider_interface` field that only included: `arch`, `claude`, `deepseek`, `groq`, `mistral`, `openai`, `gemini`. This caused validation failures for users using other supported providers like `azure_openai`, `ollama`, `qwen`, `amazon_bedrock`, `anthropic`, `together_ai`, `xai`, `moonshotai`, and `zhipu`.

**Solution:** Removed the restrictive enum and replaced it with an open string type with a description explaining how to use it for both supported and custom providers.

## Changes Made

1. `config/envoy.template.yaml`: Added Jinja2 conditional to check if port 12001 is already in use by user-defined listeners
2. `config/plano_config_schema.yaml`: Updated `provider_interface` field in both `model_providers` and `llm_providers` to use open string type instead of restrictive enum

## Testing

These fixes were validated in our custom deployment environment before submitting this PR.