### PR TITLE
feat: add OpenRouter as a first-class LLM provider

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -14,6 +14,7 @@ SUPPORTED_PROVIDERS_WITH_BASE_URL = [
     "qwen",
     "amazon_bedrock",
     "plano",
+    "openrouter",
 ]
 
 SUPPORTED_PROVIDERS_WITHOUT_BASE_URL = [

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -190,6 +190,7 @@ properties:
             - openai
             - xiaomi
             - gemini
+            - openrouter
         routing_preferences:
           type: array
           items:
@@ -238,6 +239,7 @@ properties:
             - openai
             - xiaomi
             - gemini
+            - openrouter
         routing_preferences:
           type: array
           items:

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -370,6 +370,8 @@ pub enum LlmProviderType {
     AmazonBedrock,
     #[serde(rename = "plano")]
     Plano,
+    #[serde(rename = "openrouter")]
+    OpenRouter,
 }
 
 impl Display for LlmProviderType {
@@ -391,6 +393,7 @@ impl Display for LlmProviderType {
             LlmProviderType::Qwen => write!(f, "qwen"),
             LlmProviderType::AmazonBedrock => write!(f, "amazon_bedrock"),
             LlmProviderType::Plano => write!(f, "plano"),
+            LlmProviderType::OpenRouter => write!(f, "openrouter"),
         }
     }
 }

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -44,6 +44,7 @@ pub enum ProviderId {
     Zhipu,
     Qwen,
     AmazonBedrock,
+    OpenRouter,
 }
 
 impl TryFrom<&str> for ProviderId {
@@ -71,6 +72,7 @@ impl TryFrom<&str> for ProviderId {
             "qwen" => Ok(ProviderId::Qwen),
             "amazon_bedrock" => Ok(ProviderId::AmazonBedrock),
             "amazon" => Ok(ProviderId::AmazonBedrock), // alias
+            "openrouter" => Ok(ProviderId::OpenRouter),
             _ => Err(format!("Unknown provider: {}", value)),
         }
     }
@@ -148,7 +150,8 @@ impl ProviderId {
                 | ProviderId::Ollama
                 | ProviderId::Moonshotai
                 | ProviderId::Zhipu
-                | ProviderId::Qwen,
+                | ProviderId::Qwen
+                | ProviderId::OpenRouter,
                 SupportedAPIsFromClient::AnthropicMessagesAPI(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -167,7 +170,8 @@ impl ProviderId {
                 | ProviderId::Ollama
                 | ProviderId::Moonshotai
                 | ProviderId::Zhipu
-                | ProviderId::Qwen,
+                | ProviderId::Qwen
+                | ProviderId::OpenRouter,
                 SupportedAPIsFromClient::OpenAIChatCompletions(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -234,6 +238,7 @@ impl Display for ProviderId {
             ProviderId::Zhipu => write!(f, "zhipu"),
             ProviderId::Qwen => write!(f, "qwen"),
             ProviderId::AmazonBedrock => write!(f, "amazon_bedrock"),
+            ProviderId::OpenRouter => write!(f, "openrouter"),
         }
     }
 }


### PR DESCRIPTION
Fixes #612

## Problem

OpenRouter is a popular API gateway that provides unified access to hundreds of models from providers like OpenAI, Anthropic, Google, and others via an OpenAI-compatible API. Previously, users had to configure it as an unsupported provider by manually specifying `base_url` and `provider_interface`, which was undocumented and fragile.

## Solution

Add `openrouter` as a first-class supported provider:

- **`crates/hermesllm/src/providers/id.rs`**: Add `OpenRouter` variant to `ProviderId` enum with `TryFrom<&str>` mapping and OpenAI-compatible API routing
- **`crates/common/src/configuration.rs`**: Add `OpenRouter` variant to `LlmProviderType` enum
- **`cli/planoai/config_generator.py`**: Add `"openrouter"` to `SUPPORTED_PROVIDERS_WITH_BASE_URL` (requires `base_url` since the endpoint is external)
- **`config/plano_config_schema.yaml`**: Add `"openrouter"` to the `provider_interface` enum

Users can now configure OpenRouter like this:

```yaml
model_providers:
  - model: openrouter/openai/gpt-4o
    access_key: $OPENROUTER_API_KEY
    base_url: https://openrouter.ai/api/v1
    default: true
  - model: openrouter/anthropic/claude-3-5-sonnet
    access_key: $OPENROUTER_API_KEY
    base_url: https://openrouter.ai/api/v1
```

OpenRouter uses the OpenAI-compatible chat completions API, so no new request/response types are needed.

## Testing

- All existing Rust tests pass (`cargo test --lib -p hermesllm -p common`)
- Verified `cargo check` succeeds for all modified crates