### PR TITLE
signals: restore the pre-port flag marker emoji (🚩)

### DIFF
--- a/crates/brightstaff/src/router/stress_tests.rs
+++ b/crates/brightstaff/src/router/stress_tests.rs
@@ -132,11 +132,7 @@ mod tests {
 
         let growth = after.saturating_sub(baseline);
         let growth_mb = growth as f64 / (1024.0 * 1024.0);
-        let per_request = if num_iterations > 0 {
-            growth / num_iterations
-        } else {
-            0
-        };
+        let per_request = growth.checked_div(num_iterations).unwrap_or(0);
 
         eprintln!("=== Routing Stress Test Results ===");
         eprintln!("  Iterations:      {num_iterations}");

--- a/crates/brightstaff/src/signals/analyzer.rs
+++ b/crates/brightstaff/src/signals/analyzer.rs
@@ -21,9 +21,10 @@ use super::schemas::{
 use super::text_processing::NormalizedMessage;
 
 /// Marker appended to the span operation name when concerning signals are
-/// detected. Kept in sync with the previous implementation for backward
-/// compatibility with downstream consumers.
-pub const FLAG_MARKER: &str = "[!]";
+/// detected. The 🚩 emoji (U+1F6A9) matches the pre-port implementation so
+/// downstream consumers that search for flagged traces by span-name emoji
+/// keep working.
+pub const FLAG_MARKER: &str = "\u{1F6A9}";
 
 /// ShareGPT-shaped row used as the canonical input to the analyzer's
 /// detectors. `from` is one of `"human"`, `"gpt"`, `"function_call"`,

--- a/docs/source/concepts/signals.rst
+++ b/docs/source/concepts/signals.rst
@@ -402,7 +402,8 @@ Visual Flag Marker
 
 When concerning signals are detected (disengagement present, stagnation
 count > 2, any execution failure / loop, or overall quality ``poor``/
-``severe``), the marker ``[!]`` is appended to the span's operation name.
+``severe``), the marker 🚩 (U+1F6A9) is appended to the span's operation
+name.
 This makes flagged sessions immediately visible in trace UIs without
 requiring attribute filtering.
 
@@ -420,7 +421,7 @@ Example queries against the layered keys::
     signals.execution.failure.count > 0
     signals.environment.exhaustion.count > 0
 
-For flagged sessions, search for ``[!]`` in span names.
+For flagged sessions, search for 🚩 in span names.
 
 .. image:: /_static/img/signals_trace.png
    :width: 100%
@@ -507,7 +508,7 @@ Example Span
 A concerning session, showing both layered attributes and a per-instance
 event::
 
-    # Span name: "POST /v1/chat/completions gpt-5.2 [!]"
+    # Span name: "POST /v1/chat/completions gpt-5.2 🚩"
 
     # Top-level
     signals.quality            = "severe"
@@ -619,7 +620,7 @@ Mitigation strategies:
    causes.
 
 .. tip::
-   The ``[!]`` marker in the span name provides instant visual feedback in
+   The 🚩 marker in the span name provides instant visual feedback in
    trace UIs, while the structured attributes (``signals.quality``,
    ``signals.interaction.disengagement.severity``, etc.) and per-instance
    span events enable powerful querying and drill-down in your observability

--- a/docs/source/guides/observability/tracing.rst
+++ b/docs/source/guides/observability/tracing.rst
@@ -114,11 +114,11 @@ Signals act as early warning indicators embedded in your traces:
 
 **Visual Flag Markers**
 
-When concerning signals are detected (disengagement, execution failures / loops, stagnation > 2, or ``poor`` / ``severe`` quality), Plano automatically appends a ``[!]`` marker to the span's operation name. This makes problematic traces immediately visible in your tracing UI without requiring additional queries.
+When concerning signals are detected (disengagement, execution failures / loops, stagnation > 2, or ``poor`` / ``severe`` quality), Plano automatically appends a 🚩 marker to the span's operation name. This makes problematic traces immediately visible in your tracing UI without requiring additional queries.
 
 **Example Span with Signals**::
 
-    # Span name: "POST /v1/chat/completions gpt-4 [!]"
+    # Span name: "POST /v1/chat/completions gpt-4 🚩"
     # Standard LLM attributes:
     llm.model = "gpt-4"
     llm.usage.total_tokens = 225


### PR DESCRIPTION
## Summary

Follow-up to #903 / #910. Restores the flag marker that was silently changed during the signals port.

Before #903, `FLAG_MARKER` was `U+1F6A9` (🚩) and dashboards/alerts searched span names for that glyph. #903 inadvertently rewrote the constant to `[!]`, which broke any downstream consumer keyed on the original emoji. The #910 docs pass didn't catch it — instead the docs were updated to match the (wrong) code.

This PR:

- Restores `FLAG_MARKER: &str = "\u{1F6A9}"` in `crates/brightstaff/src/signals/analyzer.rs` with a comment explaining why the specific codepoint is load-bearing, so it doesn't drift again.
- Updates the five `[!]` references added in #910 back to 🚩 across `docs/source/concepts/signals.rst` and `docs/source/guides/observability/tracing.rst` (subheading text, example span name, tip box, dashboard query hint).
- Includes a 1-line fix for a pre-existing `clippy::manual_checked_ops` warning in `router/stress_tests.rs` that became an error under rustc 1.95 + `-D warnings` (unrelated but needed to keep CI green). Kept as a separate commit for clarity.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test -p brightstaff --lib` → 164 passed, 1 ignored
- [x] `sphinx-build -b html source build/html` → clean on changed files
- [x] Rendered HTML locally; 🚩 appears in all flag-marker references on both pages

## Related

- #903: introduced the regression
- #910: documented the (incorrect) marker in the aligned docs; this PR fixes both sides together

Made with [Cursor](https://cursor.com)