### PR TITLE
fix(config): accept `vercel` and `openrouter` as provider_interface values

### DIFF
--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -396,6 +396,10 @@ pub enum LlmProviderType {
     ChatGPT,
     #[serde(rename = "digitalocean")]
     DigitalOcean,
+    #[serde(rename = "vercel")]
+    Vercel,
+    #[serde(rename = "openrouter")]
+    OpenRouter,
 }
 
 impl Display for LlmProviderType {
@@ -419,6 +423,8 @@ impl Display for LlmProviderType {
             LlmProviderType::Plano => write!(f, "plano"),
             LlmProviderType::ChatGPT => write!(f, "chatgpt"),
             LlmProviderType::DigitalOcean => write!(f, "digitalocean"),
+            LlmProviderType::Vercel => write!(f, "vercel"),
+            LlmProviderType::OpenRouter => write!(f, "openrouter"),
         }
     }
 }
@@ -755,6 +761,26 @@ mod test {
         let model_ids: Vec<String> = models.data.iter().map(|m| m.id.clone()).collect();
         assert!(model_ids.contains(&"openai-gpt4".to_string()));
         assert!(!model_ids.contains(&"plano-orchestrator".to_string()));
+    }
+
+    #[test]
+    fn test_llm_provider_type_vercel_and_openrouter_roundtrip() {
+        // Regression: brightstaff used to reject `provider_interface: vercel`
+        // (and `openrouter`) because these variants were missing from
+        // `LlmProviderType`, causing `planoai up` with the synthesized default
+        // config to crash on startup.
+        for (yaml_value, expected) in [
+            ("vercel", LlmProviderType::Vercel),
+            ("openrouter", LlmProviderType::OpenRouter),
+        ] {
+            let parsed: LlmProviderType =
+                serde_yaml::from_str(yaml_value).expect("variant should deserialize");
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.to_string(), yaml_value);
+            // to_provider_id() bridges into hermesllm; both providers must be
+            // recognized there as well or this panics.
+            let _ = parsed.to_provider_id();
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `cli/planoai/defaults.py` (#902) synthesizes `model_providers` for `vercel/*` and `openrouter/*` whenever a user runs `planoai up` without a config. Both names are accepted by the JSON schema (`config/plano_config_schema.yaml`) and dispatched correctly by `hermesllm::ProviderId`. However, `crates/common::LlmProviderType` was never extended, so brightstaff crashed at config-parse time:

  ```
  unknown variant `vercel`, expected one of `anthropic`, ..., `digitalocean`
  ```

  Repro: `planoai up` in any directory with no `plano_config.yaml`.

- Adds the two missing variants (`Vercel`, `OpenRouter`) plus their `Display` arms, so deserialization now succeeds and `LlmProviderType::to_provider_id()` correctly bridges to `hermesllm::ProviderId::{Vercel,OpenRouter}` (which already exist).

- Adds `test_llm_provider_type_vercel_and_openrouter_roundtrip` — a focused regression test that exercises the exact failing code path: serde round-trip + the `to_provider_id()` panic site.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib -p common` (39 passed including the new regression test)
- [x] Built `crates/target/release/brightstaff` and ran it against the synthesized `~/.plano/run/plano_config_rendered.yaml` that previously crashed — now parses cleanly and `server listening address=0.0.0.0:9091`.
- [ ] CI green