### PR TITLE
fix(cli): drop function-local `import yaml` shadowing module global in `up`

### DIFF
--- a/cli/planoai/main.py
+++ b/cli/planoai/main.py
@@ -441,8 +441,6 @@ def up(
         env = os.environ.copy()
         env.pop("PATH", None)
 
-        import yaml
-
         with open(plano_config_file, "r") as f:
             plano_config = yaml.safe_load(f)
 


### PR DESCRIPTION
## Summary

`planoai up` (zero-config branch) crashes immediately with `UnboundLocalError`:

```
UnboundLocalError: cannot access local variable 'yaml' where it is not associated with a value
  File "cli/planoai/main.py", line 388, in up
    yaml.safe_dump(cfg_dict, fh, sort_keys=False)
```

### Root cause

`up()` had a redundant inline `import yaml` (line 444) even though `yaml` is already imported at the module top (line 9). Python's compile-time scope analysis treated `yaml` as a function-local for the **entire** body, so the earlier use at line 388 — which was added by #890's zero-config support and runs only when no user config exists — raised `UnboundLocalError` before the inline import could execute.

The bug was latent: it only surfaces on the synthesized-default code path, which is exactly what zero-config `planoai up` exercises.

### Fix

Drop the redundant inline `import yaml`. The module-level import is sufficient and was already being used elsewhere in the same function.

## Test plan

- [x] Reproduces failing path: `planoai up` in a directory with no `plano_config.yaml` crashes on `main` at line 388 (confirmed in user terminal).
- [x] After the fix, `cd cli && uv run pytest -v` passes (31 / 31).
- [x] `pre-commit` (black + secret scan) green.
- [ ] CI green