### PR TITLE
ci: add zero-config smoke test for `planoai up` with no args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,37 @@ jobs:
         if: always()
         run: planoai down || true
 
+      # ── Zero-config path: `planoai up` with no args, no plano.yaml in cwd.
+      # Exercises the synthesize_default_config branch in cli/planoai/main.py
+      # which is otherwise never hit by the smoke test above.
+      - name: Zero-config smoke test
+        env:
+          OPENAI_API_KEY: test-key-not-used
+        run: |
+          empty_dir="$(mktemp -d)"
+          cd "$empty_dir"
+          test ! -f plano.yaml
+          planoai up
+          test -f "$HOME/.plano/default_config.yaml"
+
+      - name: Zero-config health check
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:12000/healthz > /dev/null 2>&1; then
+              echo "Zero-config health check passed"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Zero-config health check failed after 30s"
+          cat ~/.plano/run/logs/envoy.log || true
+          cat ~/.plano/run/logs/brightstaff.log || true
+          exit 1
+
+      - name: Stop plano (zero-config)
+        if: always()
+        run: planoai down || true
+
   # ──────────────────────────────────────────────
   # Single Docker build — shared by all downstream jobs
   # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The existing `native-smoke-test` only ever runs `planoai up <file>`, which skips the `synthesize_default_config` branch in `cli/planoai/main.py`. That branch is the path users hit when they run `planoai up` with no args in a directory that has no `plano.yaml`, and it was the source of the recent `UnboundLocalError: cannot access local variable 'yaml'` (fixed in #916).
- Add a follow-up step in the same job that `cd`s into an empty temp directory, runs `planoai up`, asserts `~/.plano/default_config.yaml` was written, performs a healthz check on `:12000`, and shuts down.
- Reuses the binaries already built earlier in the job, so CI runtime is essentially unchanged.

## Test plan

- [ ] CI green on this PR — confirms the zero-config path starts cleanly on `main` (post-#916).
- [ ] (Optional sanity check, locally) revert #916 on a scratch branch and confirm the new step fails with the same `UnboundLocalError`.


Made with [Cursor](https://cursor.com)