### PR TITLE
feat(providers): add first-class Qianfan provider support

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -23,6 +23,7 @@ SUPPORTED_PROVIDERS_WITHOUT_BASE_URL = [
     "mistral",
     "openai",
     "xiaomi",
+    "qianfan",
     "gemini",
     "anthropic",
     "together_ai",

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -67,6 +67,12 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         model_pattern="deepseek/*",
     ),
     ProviderDefault(
+        name="qianfan",
+        env_var="QIANFAN_API_KEY",
+        base_url="https://qianfan.baidubce.com/v2",
+        model_pattern="qianfan/*",
+    ),
+    ProviderDefault(
         name="mistral",
         env_var="MISTRAL_API_KEY",
         base_url="https://api.mistral.ai/v1",

--- a/cli/test/test_config_generator.py
+++ b/cli/test/test_config_generator.py
@@ -296,6 +296,24 @@ model_providers:
 """,
     },
     {
+        "id": "qianfan_is_supported_provider",
+        "expected_error": None,
+        "plano_config": """
+version: v0.4.0
+
+listeners:
+  - name: llm
+    type: model
+    port: 12000
+
+model_providers:
+  - model: qianfan/*
+    base_url: https://qianfan.baidubce.com/v2
+    passthrough_auth: true
+
+""",
+    },
+    {
         "id": "duplicate_routeing_preference_name",
         "expected_error": "Duplicate routing preference name",
         "plano_config": """

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -27,6 +27,7 @@ def test_zero_env_vars_produces_pure_passthrough():
         assert provider.get("default") is not True
     # All known providers should be listed.
     names = {p["name"] for p in cfg["model_providers"]}
+    assert "qianfan" in names
     assert "digitalocean" in names
     assert "vercel" in names
     assert "openrouter" in names
@@ -80,6 +81,11 @@ def test_synthesized_config_validates_against_schema():
     jsonschema.validate(cfg, _schema())
 
 
+def test_synthesized_config_with_qianfan_validates_against_schema():
+    cfg = synthesize_default_config(env={"QIANFAN_API_KEY": "qf-1"})
+    jsonschema.validate(cfg, _schema())
+
+
 def test_provider_defaults_digitalocean_is_configured():
     by_name = {p.name: p for p in PROVIDER_DEFAULTS}
     assert "digitalocean" in by_name
@@ -102,6 +108,21 @@ def test_provider_defaults_openrouter_is_configured():
     assert by_name["openrouter"].env_var == "OPENROUTER_API_KEY"
     assert by_name["openrouter"].base_url == "https://openrouter.ai/api/v1"
     assert by_name["openrouter"].model_pattern == "openrouter/*"
+
+
+def test_provider_defaults_qianfan_is_configured():
+    by_name = {p.name: p for p in PROVIDER_DEFAULTS}
+    assert "qianfan" in by_name
+    assert by_name["qianfan"].env_var == "QIANFAN_API_KEY"
+    assert by_name["qianfan"].base_url == "https://qianfan.baidubce.com/v2"
+    assert by_name["qianfan"].model_pattern == "qianfan/*"
+
+
+def test_qianfan_env_key_promotes_to_env_keyed():
+    cfg = synthesize_default_config(env={"QIANFAN_API_KEY": "qf-1"})
+    by_name = {p["name"]: p for p in cfg["model_providers"]}
+    assert by_name["qianfan"].get("access_key") == "$QIANFAN_API_KEY"
+    assert by_name["qianfan"].get("passthrough_auth") is None
 
 
 def test_openrouter_env_key_promotes_to_env_keyed():

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -189,6 +189,7 @@ properties:
             - mistral
             - openai
             - xiaomi
+            - qianfan
             - gemini
             - chatgpt
             - digitalocean
@@ -247,6 +248,7 @@ properties:
             - mistral
             - openai
             - xiaomi
+            - qianfan
             - gemini
             - chatgpt
             - digitalocean

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -372,6 +372,8 @@ pub enum LlmProviderType {
     OpenAI,
     #[serde(rename = "xiaomi")]
     Xiaomi,
+    #[serde(rename = "qianfan")]
+    Qianfan,
     #[serde(rename = "gemini")]
     Gemini,
     #[serde(rename = "xai")]
@@ -412,6 +414,7 @@ impl Display for LlmProviderType {
             LlmProviderType::Mistral => write!(f, "mistral"),
             LlmProviderType::OpenAI => write!(f, "openai"),
             LlmProviderType::Xiaomi => write!(f, "xiaomi"),
+            LlmProviderType::Qianfan => write!(f, "qianfan"),
             LlmProviderType::XAI => write!(f, "xai"),
             LlmProviderType::TogetherAI => write!(f, "together_ai"),
             LlmProviderType::AzureOpenAI => write!(f, "azure_openai"),
@@ -781,6 +784,15 @@ mod test {
             // recognized there as well or this panics.
             let _ = parsed.to_provider_id();
         }
+    }
+
+    #[test]
+    fn test_llm_provider_type_qianfan_roundtrip() {
+        let parsed: LlmProviderType =
+            serde_yaml::from_str("qianfan").expect("variant should deserialize");
+        assert_eq!(parsed, LlmProviderType::Qianfan);
+        assert_eq!(parsed.to_string(), "qianfan");
+        assert_eq!(parsed.to_provider_id(), hermesllm::ProviderId::Qianfan);
     }
 
     #[test]

--- a/crates/hermesllm/src/clients/endpoints.rs
+++ b/crates/hermesllm/src/clients/endpoints.rs
@@ -133,6 +133,13 @@ impl SupportedAPIsFromClient {
                         build_endpoint("/v1", endpoint_suffix)
                     }
                 }
+                ProviderId::Qianfan => {
+                    if request_path.starts_with("/v1/") {
+                        build_endpoint("/v2", endpoint_suffix)
+                    } else {
+                        build_endpoint("/v1", endpoint_suffix)
+                    }
+                }
                 ProviderId::AzureOpenAI => {
                     if request_path.starts_with("/v1/") {
                         let suffix = endpoint_suffix.trim_start_matches('/');
@@ -398,6 +405,19 @@ mod tests {
                 false
             ),
             "/compatible-mode/v1/chat/completions"
+        );
+
+        // Test Qianfan provider
+        assert_eq!(
+            api.target_endpoint_for_provider(
+                &ProviderId::Qianfan,
+                "/v1/chat/completions",
+                "ernie-4.0-turbo-8k",
+                false,
+                None,
+                false
+            ),
+            "/v2/chat/completions"
         );
 
         // Test Azure OpenAI provider

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -29,6 +29,7 @@ fn load_provider_models() -> &'static HashMap<String, Vec<String>> {
 pub enum ProviderId {
     OpenAI,
     Xiaomi,
+    Qianfan,
     Mistral,
     Deepseek,
     Groq,
@@ -57,6 +58,8 @@ impl TryFrom<&str> for ProviderId {
         match value.to_lowercase().as_str() {
             "openai" => Ok(ProviderId::OpenAI),
             "xiaomi" => Ok(ProviderId::Xiaomi),
+            "qianfan" => Ok(ProviderId::Qianfan),
+            "baidu" => Ok(ProviderId::Qianfan), // alias
             "mistral" => Ok(ProviderId::Mistral),
             "deepseek" => Ok(ProviderId::Deepseek),
             "groq" => Ok(ProviderId::Groq),
@@ -97,6 +100,7 @@ impl ProviderId {
             ProviderId::Gemini => "google",
             ProviderId::OpenAI => "openai",
             ProviderId::Xiaomi => "xiaomi",
+            ProviderId::Qianfan => "qianfan",
             ProviderId::Anthropic => "anthropic",
             ProviderId::Mistral => "mistralai",
             ProviderId::Deepseek => "deepseek",
@@ -159,6 +163,7 @@ impl ProviderId {
             (
                 ProviderId::OpenAI
                 | ProviderId::Xiaomi
+                | ProviderId::Qianfan
                 | ProviderId::Groq
                 | ProviderId::Mistral
                 | ProviderId::Deepseek
@@ -181,6 +186,7 @@ impl ProviderId {
             (
                 ProviderId::OpenAI
                 | ProviderId::Xiaomi
+                | ProviderId::Qianfan
                 | ProviderId::Groq
                 | ProviderId::Mistral
                 | ProviderId::Deepseek
@@ -248,6 +254,7 @@ impl Display for ProviderId {
         match self {
             ProviderId::OpenAI => write!(f, "OpenAI"),
             ProviderId::Xiaomi => write!(f, "xiaomi"),
+            ProviderId::Qianfan => write!(f, "qianfan"),
             ProviderId::Mistral => write!(f, "Mistral"),
             ProviderId::Deepseek => write!(f, "Deepseek"),
             ProviderId::Groq => write!(f, "Groq"),
@@ -381,6 +388,13 @@ mod tests {
     }
 
     #[test]
+    fn test_qianfan_parsing_and_display() {
+        assert_eq!(ProviderId::try_from("qianfan"), Ok(ProviderId::Qianfan));
+        assert_eq!(ProviderId::try_from("baidu"), Ok(ProviderId::Qianfan));
+        assert_eq!(ProviderId::Qianfan.to_string(), "qianfan");
+    }
+
+    #[test]
     fn test_vercel_compatible_api() {
         use crate::clients::endpoints::{SupportedAPIsFromClient, SupportedUpstreamAPIs};
 
@@ -433,6 +447,34 @@ mod tests {
         assert!(
             matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
             "OpenRouter should translate Responses API client to OpenAIChatCompletions upstream"
+        );
+    }
+
+    #[test]
+    fn test_qianfan_compatible_api() {
+        use crate::clients::endpoints::{SupportedAPIsFromClient, SupportedUpstreamAPIs};
+
+        let openai_client =
+            SupportedAPIsFromClient::OpenAIChatCompletions(OpenAIApi::ChatCompletions);
+        let upstream = ProviderId::Qianfan.compatible_api_for_client(&openai_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "Qianfan should map OpenAI client to OpenAIChatCompletions upstream"
+        );
+
+        let anthropic_client =
+            SupportedAPIsFromClient::AnthropicMessagesAPI(AnthropicApi::Messages);
+        let upstream = ProviderId::Qianfan.compatible_api_for_client(&anthropic_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "Qianfan should translate Anthropic client to OpenAIChatCompletions upstream"
+        );
+
+        let responses_client = SupportedAPIsFromClient::OpenAIResponsesAPI(OpenAIApi::Responses);
+        let upstream = ProviderId::Qianfan.compatible_api_for_client(&responses_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "Qianfan should translate Responses API client to OpenAIChatCompletions upstream"
         );
     }
 

--- a/docs/source/concepts/llm_providers/supported_providers.rst
+++ b/docs/source/concepts/llm_providers/supported_providers.rst
@@ -547,6 +547,31 @@ Xiaomi MiMo
       - model: xiaomi/mimo-v2-omni
         access_key: $MIMO_API_KEY
 
+Baidu Qianfan
+~~~~~~~~~~~~~
+
+**Provider Prefix:** ``qianfan/``
+
+**API Endpoint:** ``/v2/chat/completions`` through Qianfan's OpenAI-compatible API.
+
+**Authentication:** API Key - Get your API key from `Baidu AI Cloud Qianfan <https://console.bce.baidu.com/qianfan/ais/console/applicationConsole/application>`_ and set ``QIANFAN_API_KEY``.
+
+**Supported Chat Models:** All Qianfan chat models available through the OpenAI-compatible API, including ERNIE models and future chat model releases.
+
+**Configuration Examples:**
+
+.. code-block:: yaml
+
+    llm_providers:
+      # Configure Qianfan models with wildcard routing
+      - model: qianfan/*
+        access_key: $QIANFAN_API_KEY
+
+      # Or configure a specific ERNIE model
+      - model: qianfan/ernie-4.0-turbo-8k
+        access_key: $QIANFAN_API_KEY
+        default: true
+
 Providers Requiring Base URL
 ----------------------------
 


### PR DESCRIPTION
## What changed

- Adds `qianfan` as a first-class OpenAI-compatible provider.
- Registers `qianfan/*` in the CLI config generator and JSON schema.
- Adds zero-config defaults using `QIANFAN_API_KEY` and `https://qianfan.baidubce.com/v2`.
- Adds `ProviderId::Qianfan` / `LlmProviderType::Qianfan` with parse, display, and round-trip coverage.
- Routes OpenAI-compatible client requests from `/v1/chat/completions` to Qianfan's `/v2/chat/completions` upstream path.
- Documents Baidu Qianfan configuration examples.

## Why this change is needed

Qianfan supports OpenAI-compatible chat completions, but using it today requires users to configure a custom provider with both `base_url` and `provider_interface: openai`.

This makes Qianfan match the existing first-class provider flow used by other OpenAI-compatible providers: users can configure `qianfan/*` directly, use `QIANFAN_API_KEY` in zero-config setups, and rely on Plano's validation and routing behavior.

## User impact

Users can configure Qianfan with:

```yaml
model_providers:
  - model: qianfan/*
    access_key: $QIANFAN_API_KEY
```

or a specific model:

```yaml
model_providers:
  - model: qianfan/ernie-4.0-turbo-8k
    access_key: $QIANFAN_API_KEY
```

Plano routes OpenAI-compatible chat completion requests to `https://qianfan.baidubce.com/v2/chat/completions`.

## Tests / validation

- `cd cli && uv run pytest -q`
  - 102 passed
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p hermesllm test_qianfan --lib`
  - 2 passed
- `cd crates && cargo test -p common test_llm_provider_type_qianfan_roundtrip --lib`
  - 1 passed
- `git diff --check`

## Notes for reviewers

- This PR intentionally keeps Qianfan as an OpenAI-compatible provider and does not add native Qianfan-specific request/response transforms.
- `baidu` is accepted as a provider alias in `ProviderId`, but the canonical config prefix is `qianfan`.
