### PR TITLE
docs: update access logging guide to use planoai logs command

### DIFF
--- a/docs/source/guides/observability/access_logging.rst
+++ b/docs/source/guides/observability/access_logging.rst
@@ -19,24 +19,30 @@ Key Features
 How It Works
 ^^^^^^^^^^^^
 
-Plano exposes access logs for every call it manages on your behalf. By default these access logs can be found under ``~/plano_logs``. For example:
+Plano exposes access logs for every call it manages on your behalf. Use the ``planoai logs`` command to stream them:
 
 .. code-block:: console
 
-  $ tail -F ~/plano_logs/access_*.log
+  $ planoai logs --follow
 
-  ==> /Users/username/plano_logs/access_llm.log <==
+  ==> /Users/username/.plano/run/logs/access_llm.log <==
   [2024-10-10T03:55:49.537Z] "POST /v1/chat/completions HTTP/1.1" 0 DC 0 0 770 - "-" "OpenAI/Python 1.51.0" "469793af-b25f-9b57-b265-f376e8d8c586" "api.openai.com" "162.159.140.245:443"
 
-  ==> /Users/username/plano_logs/access_internal.log <==
+  ==> /Users/username/.plano/run/logs/access_internal.log <==
   [2024-10-10T03:56:03.906Z] "POST /embeddings HTTP/1.1" 200 - 52 21797 54 53 "-" "-" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "model_server" "192.168.65.254:51000"
   [2024-10-10T03:56:03.961Z] "POST /zeroshot HTTP/1.1" 200 - 106 218 87 87 "-" "-" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "model_server" "192.168.65.254:51000"
   [2024-10-10T03:56:04.050Z] "POST /v1/chat/completions HTTP/1.1" 200 - 1301 614 441 441 "-" "-" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "model_server" "192.168.65.254:51000"
   [2024-10-10T03:56:04.492Z] "POST /hallucination HTTP/1.1" 200 - 556 127 104 104 "-" "-" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "model_server" "192.168.65.254:51000"
   [2024-10-10T03:56:04.598Z] "POST /insurance_claim_details HTTP/1.1" 200 - 447 125 17 17 "-" "-" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "api_server" "192.168.65.254:18083"
 
-  ==> /Users/username/plano_logs/access_ingress.log <==
+  ==> /Users/username/.plano/run/logs/access_ingress.log <==
   [2024-10-10T03:56:03.905Z] "POST /v1/chat/completions HTTP/1.1" 200 - 463 1022 1695 984 "-" "OpenAI/Python 1.51.0" "604197fe-2a5b-95a2-9367-1d6b30cfc845" "plano_llm_listener" "0.0.0.0:12000"
+
+When running in Docker mode (``planoai up --docker``), add ``--docker`` to the logs command:
+
+.. code-block:: console
+
+  $ planoai logs --follow --docker
 
 
 Log Format


### PR DESCRIPTION
Relates to #648

## Problem

The access logging guide showed `tail -F ~/plano_logs/access_*.log` to view access logs. This command only works when using the dev Docker Compose setup (`config/docker-compose.dev.yaml`) which mounts `~/plano_logs:/var/log/`. It does not work with the standard `planoai up` workflow, where logs live inside the container (native mode: `~/.plano/run/logs/`, Docker mode: `/var/log/` inside the container).

## Solution

Replace the manual `tail` command with `planoai logs --follow`, which works correctly in both modes:
- Native mode (default): reads from `~/.plano/run/logs/access_*.log`
- Docker mode: uses `docker exec` to tail logs inside the container

Also add a note showing `planoai logs --follow --docker` for users running in Docker mode.

## Testing

Verified against the CLI implementation in `cli/planoai/utils.py` and `cli/planoai/native_runner.py`.