### PR TITLE
feat(planohelper, brightstaff): add Slack ops bot and enable redis TLS

### DIFF
--- a/apps/planohelper/.env.example
+++ b/apps/planohelper/.env.example
@@ -1,0 +1,12 @@
+# Slack signing secret from the Slack app's Basic Information page.
+SLACK_SIGNING_SECRET=
+
+# Comma-separated Slack user IDs allowed to invoke privileged commands.
+# Example: U01ABCDE,U02FGHIJ
+SLACK_ALLOWED_USER_IDS=
+
+# GitHub fine-grained PAT with `actions:write` on the target repo.
+GITHUB_TOKEN=
+
+# owner/repo, e.g. katanemo/plano
+GITHUB_REPO=katanemo/plano

--- a/apps/planohelper/.gitignore
+++ b/apps/planohelper/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.vercel
+.env
+.env*.local
+*.tsbuildinfo

--- a/apps/planohelper/README.md
+++ b/apps/planohelper/README.md
@@ -1,0 +1,133 @@
+# PlanoHelper
+
+A lightweight Slack bot (Next.js app on Vercel) that handles slash commands for
+Plano ops work. Today it ships one command:
+
+- `/update-providers` — refresh `crates/hermesllm/src/bin/provider_models.yaml`
+and open a PR.
+
+## How it works
+
+```
+Slack user → /update-providers
+  → Vercel (this app): verify signature, check user allowlist, ack in <3s
+    → GitHub repository_dispatch (event_type: update-providers)
+      → GitHub Actions: run fetch_models, open PR, reply to Slack response_url
+```
+
+Slack slash commands must be acknowledged within 3 seconds, so Vercel only
+dispatches the workflow and returns an ephemeral ack. The GitHub Actions
+workflow (`.github/workflows/update-providers.yml`) does the heavy lifting and
+posts the PR link back to the same Slack thread via the `response_url`.
+
+## Adding a new slash command
+
+1. Create `src/lib/commands/<name>.ts` exporting a `SlashCommand`.
+2. Add it to the array in `src/lib/commands/registry.ts`.
+3. Register the command in your Slack app's "Slash Commands" section with the
+  same name (`/your-command`) pointed at
+   `https://<vercel-domain>/api/slack/commands`.
+4. If the handler dispatches a workflow, add a matching workflow under
+  `.github/workflows/` listening for that `repository_dispatch` event type.
+
+The Slack route (`src/app/api/slack/commands/route.ts`) handles signature
+verification and user allowlisting once for every command.
+
+## Setup
+
+### 1. Create the Slack app
+
+From [https://api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**,
+name it **PlanoHelper**.
+
+- **Slash Commands** → **Create New Command**
+  - Command: `/update-providers`
+  - Request URL: `https://<your-vercel-domain>/api/slack/commands`
+  - Short description: `Refresh provider_models.yaml and open a PR`
+  - Usage hint: *(leave blank)*
+- **OAuth & Permissions** → Bot Token Scopes: `commands` is the only required scope.
+- Install the app to your workspace.
+- Copy the **Signing Secret** from **Basic Information**.
+
+### 2. Configure Vercel
+
+Create a **new, standalone Vercel project** (not attached to the marketing
+sites) pointing at this monorepo. Set **Root Directory** to `apps/planohelper`.
+Framework preset is auto-detected as Next.js.
+
+Recommended project settings:
+
+- **Deployment Protection** → enable **Vercel Authentication** for **Preview**
+deploys. Production stays public so Slack can reach it.
+- **Environment Variables** → add the values below, scoped to **Production**
+only (preview deploys don't need a working `GITHUB_TOKEN`).
+
+
+| Name                     | Value                                                    |
+| ------------------------ | -------------------------------------------------------- |
+| `SLACK_SIGNING_SECRET`   | From the Slack app's Basic Information page              |
+| `SLACK_ALLOWED_USER_IDS` | Comma-separated Slack user IDs, e.g. `U01ABCDE,U02FGHIJ` |
+| `GITHUB_TOKEN`           | Fine-grained PAT — see step 4                            |
+| `GITHUB_REPO`            | `katanemo/plano`                                         |
+
+
+After deploy, the health probe at `https://<vercel-domain>/api/health` should
+return `{ ok: true }`.
+
+### 3. Configure GitHub repo secrets
+
+Under **Settings → Secrets and variables → Actions** add:
+
+- Provider API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
+`GROK_API_KEY`, `DASHSCOPE_API_KEY`, `MOONSHOT_API_KEY`, `ZHIPU_API_KEY`,
+`GOOGLE_API_KEY`
+- AWS for Bedrock: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
+
+Missing keys are OK — `fetch_models` skips the corresponding providers.
+
+### 4. GitHub PAT for `GITHUB_TOKEN`
+
+Create a **fine-grained** PAT at
+[https://github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
+
+- **Resource owner**: `katanemo` (must be selected — defaults to your personal
+account, which is a common gotcha. The org must have fine-grained PATs
+enabled in its policy.)
+- **Repository access**: Only select repositories → `katanemo/plano`
+- **Repository permissions**:
+  - **Contents: Read and write** — required to call
+  `POST /repos/{owner}/{repo}/dispatches` (the `repository_dispatch` event
+  this app sends).
+  - *Metadata: Read-only* is auto-included.
+- No other permissions are needed. The workflow itself uses GitHub's built-in
+`GITHUB_TOKEN` (with `contents: write` + `pull-requests: write` declared in
+the workflow) to create the branch, commit, and open the PR — your PAT does
+not need PR or Actions scopes.
+
+If your PAT can't see `katanemo/plano`, the most common causes are: Resource
+owner dropdown still set to your personal account; SAML SSO session not
+refreshed; or org policy restricting which repos PATs can target.
+
+### 5. Find your Slack user ID
+
+In Slack → your profile → **More (⋯)** → **Copy member ID**. Paste it into
+`SLACK_ALLOWED_USER_IDS`.
+
+## Local development
+
+```bash
+cd apps/planohelper
+cp .env.example .env.local
+# fill in values
+npm run dev
+```
+
+Expose the dev server with ngrok or similar and point the Slack slash command
+request URL at `https://<tunnel>/api/slack/commands`.
+
+## Scripts
+
+- `npm run dev` — Next.js dev server
+- `npm run build` — production build
+- `npm run lint` — Biome lint
+- `npm run typecheck` — `tsc --noEmit`

--- a/apps/planohelper/biome.json
+++ b/apps/planohelper/biome.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    },
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/apps/planohelper/next.config.ts
+++ b/apps/planohelper/next.config.ts
@@ -1,0 +1,20 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  experimental: {
+    externalDir: true,
+  },
+  webpack: (config) => {
+    config.resolve.modules = [
+      ...(config.resolve.modules || []),
+      "node_modules",
+      "../../node_modules",
+    ];
+    return config;
+  },
+  turbopack: {
+    resolveAlias: {},
+  },
+};
+
+export default nextConfig;

--- a/apps/planohelper/package.json
+++ b/apps/planohelper/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@katanemo/planohelper",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "biome check",
+    "format": "biome format --write",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .next"
+  },
+  "dependencies": {
+    "next": "^16.1.6",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.2.0",
+    "@katanemo/tsconfig": "*",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/apps/planohelper/src/app/api/health/route.ts
+++ b/apps/planohelper/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export function GET() {
+  return NextResponse.json({ ok: true, service: "planohelper" });
+}

--- a/apps/planohelper/src/app/api/slack/commands/route.ts
+++ b/apps/planohelper/src/app/api/slack/commands/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { isAllowed } from "@/lib/auth";
+import { getCommand } from "@/lib/commands/registry";
+import type { SlashCommandContext } from "@/lib/commands/types";
+import { verifySlackSignature } from "@/lib/slack/verify";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function ephemeral(text: string) {
+  return NextResponse.json({ response_type: "ephemeral", text });
+}
+
+export async function POST(req: Request) {
+  const rawBody = await req.text();
+
+  const signingSecret = process.env.SLACK_SIGNING_SECRET ?? "";
+  const verification = verifySlackSignature({
+    signingSecret,
+    timestamp: req.headers.get("x-slack-request-timestamp"),
+    signature: req.headers.get("x-slack-signature"),
+    rawBody,
+  });
+  if (!verification.ok) {
+    return new NextResponse(`Unauthorized: ${verification.reason}`, {
+      status: 401,
+    });
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const ctx: SlashCommandContext = {
+    command: params.get("command") ?? "",
+    text: params.get("text") ?? "",
+    userId: params.get("user_id") ?? "",
+    userName: params.get("user_name") ?? "",
+    channelId: params.get("channel_id") ?? "",
+    channelName: params.get("channel_name") ?? "",
+    teamId: params.get("team_id") ?? "",
+    responseUrl: params.get("response_url") ?? "",
+    triggerId: params.get("trigger_id") ?? "",
+  };
+
+  if (!ctx.command) {
+    return ephemeral("Missing `command` field.");
+  }
+
+  if (!isAllowed(ctx.userId)) {
+    return ephemeral(
+      `Sorry, you aren't on the allowlist for PlanoHelper commands. Ask an admin to add \`${ctx.userId}\` to \`SLACK_ALLOWED_USER_IDS\`.`,
+    );
+  }
+
+  const cmd = getCommand(ctx.command);
+  if (!cmd) {
+    return ephemeral(`Unknown command \`${ctx.command}\`.`);
+  }
+
+  try {
+    const ack = await cmd.handler(ctx);
+    return NextResponse.json(ack);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[planohelper] ${ctx.command} failed:`, err);
+    return ephemeral(`:warning: Failed to run \`${ctx.command}\`: ${msg}`);
+  }
+}

--- a/apps/planohelper/src/app/layout.tsx
+++ b/apps/planohelper/src/app/layout.tsx
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: "PlanoHelper",
+  description: "Slack bot for Plano ops",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/planohelper/src/app/page.tsx
+++ b/apps/planohelper/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main style={{ fontFamily: "system-ui", padding: "2rem" }}>
+      <h1>PlanoHelper</h1>
+      <p>Slack bot for Plano ops. See /api/health.</p>
+    </main>
+  );
+}

--- a/apps/planohelper/src/lib/auth.ts
+++ b/apps/planohelper/src/lib/auth.ts
@@ -1,0 +1,15 @@
+/**
+ * Check whether a Slack user is allowed to invoke privileged commands.
+ *
+ * `SLACK_ALLOWED_USER_IDS` is a comma-separated list of Slack user IDs
+ * (e.g. `U01ABCDE,U02FGHIJ`). Empty or unset means no one is allowed.
+ */
+export function isAllowed(userId: string | undefined | null): boolean {
+  if (!userId) return false;
+  const raw = process.env.SLACK_ALLOWED_USER_IDS ?? "";
+  const allowed = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return allowed.includes(userId);
+}

--- a/apps/planohelper/src/lib/commands/registry.ts
+++ b/apps/planohelper/src/lib/commands/registry.ts
@@ -1,0 +1,14 @@
+import type { SlashCommand } from "@/lib/commands/types";
+import { updateProviders } from "@/lib/commands/update-providers";
+
+const commands: SlashCommand[] = [updateProviders];
+
+const byName = new Map<string, SlashCommand>(commands.map((c) => [c.name, c]));
+
+export function getCommand(name: string): SlashCommand | undefined {
+  return byName.get(name);
+}
+
+export function listCommands(): SlashCommand[] {
+  return [...commands];
+}

--- a/apps/planohelper/src/lib/commands/types.ts
+++ b/apps/planohelper/src/lib/commands/types.ts
@@ -1,0 +1,24 @@
+import type { SlackAck } from "@/lib/slack/respond";
+
+/**
+ * Parsed Slack slash command payload.
+ *
+ * See https://api.slack.com/interactivity/slash-commands#app_command_handling
+ */
+export interface SlashCommandContext {
+  command: string;
+  text: string;
+  userId: string;
+  userName: string;
+  channelId: string;
+  channelName: string;
+  teamId: string;
+  responseUrl: string;
+  triggerId: string;
+}
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  handler: (ctx: SlashCommandContext) => Promise<SlackAck>;
+}

--- a/apps/planohelper/src/lib/commands/update-providers.ts
+++ b/apps/planohelper/src/lib/commands/update-providers.ts
@@ -1,0 +1,29 @@
+import type { SlashCommand } from "@/lib/commands/types";
+import { dispatchWorkflow } from "@/lib/github";
+
+export const updateProviders: SlashCommand = {
+  name: "/update-providers",
+  description: "Refresh provider_models.yaml and open a PR.",
+  async handler(ctx) {
+    await dispatchWorkflow("update-providers", {
+      response_url: ctx.responseUrl,
+      user_id: ctx.userId,
+      user_name: ctx.userName,
+      channel_id: ctx.channelId,
+    });
+
+    return {
+      response_type: "ephemeral",
+      text: "Ok - I'm updating provider_models.yaml and will reply here with the PR link when it's ready.",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":hourglass_flowing_sand: Kicking off provider model refresh. I'll reply here with the PR link when it's ready.",
+          },
+        },
+      ],
+    };
+  },
+};

--- a/apps/planohelper/src/lib/github.ts
+++ b/apps/planohelper/src/lib/github.ts
@@ -1,0 +1,39 @@
+/**
+ * Dispatch a `repository_dispatch` event to the configured GitHub repo.
+ *
+ * See https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+ *
+ * Requires a PAT or fine-grained token with `actions:write` on the target repo,
+ * available in `GITHUB_TOKEN`. `GITHUB_REPO` is `owner/repo`.
+ */
+export async function dispatchWorkflow(
+  eventType: string,
+  clientPayload: Record<string, unknown>,
+): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+  if (!token) throw new Error("GITHUB_TOKEN is not set");
+  if (!repo) throw new Error("GITHUB_REPO is not set");
+
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      "User-Agent": "planohelper",
+    },
+    body: JSON.stringify({
+      event_type: eventType,
+      client_payload: clientPayload,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `GitHub dispatch ${eventType} failed (${res.status}): ${body}`,
+    );
+  }
+}

--- a/apps/planohelper/src/lib/slack/respond.ts
+++ b/apps/planohelper/src/lib/slack/respond.ts
@@ -1,0 +1,33 @@
+export type SlackResponseType = "ephemeral" | "in_channel";
+
+export interface SlackBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SlackAck {
+  response_type: SlackResponseType;
+  text: string;
+  blocks?: SlackBlock[];
+  replace_original?: boolean;
+}
+
+/**
+ * Post a delayed response to the `response_url` Slack included with a slash
+ * command. `response_url` is valid for 30 minutes and accepts up to 5 POSTs.
+ */
+export async function postToResponseUrl(
+  responseUrl: string,
+  body: SlackAck,
+): Promise<void> {
+  const res = await fetch(responseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Slack response_url ${responseUrl} returned ${res.status}: ${await res.text()}`,
+    );
+  }
+}

--- a/apps/planohelper/src/lib/slack/verify.ts
+++ b/apps/planohelper/src/lib/slack/verify.ts
@@ -1,0 +1,56 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const REPLAY_WINDOW_SECONDS = 60 * 5;
+
+export type VerifyResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Verify a Slack request signature.
+ *
+ * See https://api.slack.com/authentication/verifying-requests-from-slack
+ *
+ * Slack signs `v0:{timestamp}:{rawBody}` with HMAC-SHA256 using the signing
+ * secret, hex-encoded and prefixed with `v0=`. We reject timestamps older than
+ * 5 minutes to prevent replay attacks.
+ */
+export function verifySlackSignature(params: {
+  signingSecret: string;
+  timestamp: string | null;
+  signature: string | null;
+  rawBody: string;
+  now?: number;
+}): VerifyResult {
+  const { signingSecret, timestamp, signature, rawBody } = params;
+
+  if (!signingSecret) {
+    return { ok: false, reason: "missing signing secret" };
+  }
+  if (!timestamp || !signature) {
+    return { ok: false, reason: "missing signature headers" };
+  }
+
+  const tsNum = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(tsNum)) {
+    return { ok: false, reason: "invalid timestamp" };
+  }
+
+  const nowSeconds = Math.floor((params.now ?? Date.now()) / 1000);
+  if (Math.abs(nowSeconds - tsNum) > REPLAY_WINDOW_SECONDS) {
+    return { ok: false, reason: "stale timestamp" };
+  }
+
+  const base = `v0:${timestamp}:${rawBody}`;
+  const digest = createHmac("sha256", signingSecret).update(base).digest("hex");
+  const expected = `v0=${digest}`;
+
+  const expectedBuf = Buffer.from(expected, "utf8");
+  const actualBuf = Buffer.from(signature, "utf8");
+  if (expectedBuf.length !== actualBuf.length) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+  if (!timingSafeEqual(expectedBuf, actualBuf)) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+
+  return { ok: true };
+}

--- a/apps/planohelper/tsconfig.json
+++ b/apps/planohelper/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@katanemo/tsconfig/nextjs.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/planohelper/vercel.json
+++ b/apps/planohelper/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "src/app/api/slack/commands/route.ts": {
+      "maxDuration": 10
+    }
+  }
+}

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2752,12 +2752,18 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.23.38",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2965,7 +2971,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -2989,6 +3008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4024,7 +4052,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4276,6 +4304,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/brightstaff/Cargo.toml
+++ b/crates/brightstaff/Cargo.toml
@@ -43,7 +43,7 @@ lru = "0.12"
 metrics = "0.23"
 metrics-exporter-prometheus = { version = "0.15", default-features = false, features = ["http-listener"] }
 metrics-process = "2.1"
-redis = { version = "0.27", features = ["tokio-comp"] }
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "tls-rustls-webpki-roots"] }
 reqwest = { version = "0.12.15", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
## Summary

- **planohelper**: new Next.js Slack bot (deployed on Vercel) that handles ops slash commands. Initial command `/update-providers` verifies the Slack signature + user allowlist, acks within Slack's 3s window, then dispatches a GitHub Actions `repository_dispatch` event (`update-providers`) which runs `fetch_models`, opens a PR, and replies back via the Slack `response_url`. Adding new commands is just a new file in `src/lib/commands/` registered in `registry.ts`.
- **brightstaff redis TLS**: turn on the `redis` crate's `tokio-rustls-comp` and `tls-rustls-webpki-roots` features so `rediss://` URLs in `routing.session_cache.url` actually negotiate TLS. Previously this failed with `failed to connect to Redis session cache: can't connect with TLS, the feature is not enabled`. Uses pure-Rust rustls + bundled Mozilla CA roots, so no system OpenSSL is needed in the slim runtime image. Works out of the box with managed Redis (ElastiCache, Azure Cache, Redis Cloud, Upstash, etc.).

## Test plan

- [ ] `cargo build -p brightstaff` succeeds (verified locally).
- [ ] Point `routing.session_cache.url` at a managed `rediss://` endpoint and confirm brightstaff connects without the TLS feature error.
- [ ] Deploy `apps/planohelper` to Vercel, configure `SLACK_SIGNING_SECRET`, `GITHUB_TOKEN`, `GITHUB_REPO`, and Slack-user allowlist env vars; trigger `/update-providers` from Slack and confirm the workflow runs and posts the PR link back.
- [ ] Verify `/api/health` returns 200 on the deployed Vercel app.