### PR TITLE
fix(brightstaff): enable TLS for redis session cache

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2752,12 +2752,18 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.23.38",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2965,7 +2971,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -2989,6 +3008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4024,7 +4052,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4276,6 +4304,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/brightstaff/Cargo.toml
+++ b/crates/brightstaff/Cargo.toml
@@ -43,7 +43,7 @@ lru = "0.12"
 metrics = "0.23"
 metrics-exporter-prometheus = { version = "0.15", default-features = false, features = ["http-listener"] }
 metrics-process = "2.1"
-redis = { version = "0.27", features = ["tokio-comp"] }
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "tls-rustls-webpki-roots"] }
 reqwest = { version = "0.12.15", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
## Summary

Connecting the brightstaff session cache to a TLS Redis (`rediss://...`) currently fails at startup with:

> `failed to connect to Redis session cache: can't connect with TLS, the feature is not enabled - InvalidClientConfig`

The `redis` crate in `crates/brightstaff/Cargo.toml` only had `tokio-comp` enabled, so any `rediss://` URL was rejected by the client. This PR enables TLS by adding the `tokio-rustls-comp` and `tls-rustls-webpki-roots` features.

- Uses pure-Rust `rustls` (no system OpenSSL needed in the `python:3.14-slim` runtime image).
- Bundles Mozilla CA roots via `webpki-roots`, so managed Redis services (AWS ElastiCache, Azure Cache for Redis, Redis Cloud, Upstash, etc.) work out of the box.
- No config-schema or API changes — `routing.session_cache.url` already accepts `rediss://`, and the docs at `docs/source/resources/includes/plano_config_full_reference.yaml` already advertise it.

## Caveats

- Cert verification is on by default. Self-signed / private-CA Redis won't work without further changes (would need `tls-rustls-insecure` + `?insecure=true` in the URL, or switching to `tokio-native-tls-comp` to use the system trust store). Happy to add either if needed.

## Test plan

- [x] `cargo build -p brightstaff` succeeds locally with the new features.
- [ ] Point `routing.session_cache.url` at a managed `rediss://` endpoint in a deployed image and confirm brightstaff starts cleanly (no `InvalidClientConfig`) and that affinity reads/writes work.
- [ ] Sanity-check that plain `redis://` URLs still connect (tokio-comp path unchanged).