### PR TITLE
Validate output_filters references during config generation

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -562,15 +562,15 @@ def validate_and_render_schema():
                     "Please provide model_providers either under listeners or at root level, not both. Currently we don't support multiple listeners with model_providers"
                 )
 
-    # Validate input_filters IDs on listeners reference valid agent/filter IDs
+    # Validate listener-level filter IDs reference valid agent/filter IDs.
     for listener in listeners:
-        listener_input_filters = listener.get("input_filters", [])
-        for fc_id in listener_input_filters:
-            if fc_id not in agent_id_keys:
-                raise Exception(
-                    f"Listener '{listener.get('name', 'unknown')}' references input_filters id '{fc_id}' "
-                    f"which is not defined in agents or filters. Available ids: {', '.join(sorted(agent_id_keys))}"
-                )
+        for filter_field in ("input_filters", "output_filters"):
+            for fc_id in listener.get(filter_field, []):
+                if fc_id not in agent_id_keys:
+                    raise Exception(
+                        f"Listener '{listener.get('name', 'unknown')}' references {filter_field} id '{fc_id}' "
+                        f"which is not defined in agents or filters. Available ids: {', '.join(sorted(agent_id_keys))}"
+                    )
 
     # Validate model aliases if present
     if "model_aliases" in config_yaml:

--- a/cli/test/test_config_generator.py
+++ b/cli/test/test_config_generator.py
@@ -329,6 +329,33 @@ tracing:
 
 """,
     },
+    {
+        "id": "unknown_listener_output_filter",
+        "expected_error": "references output_filters id 'missing_output_guard'",
+        "plano_config": """
+version: v0.4.0
+
+filters:
+  - id: input_guard
+    url: http://localhost:10500
+    type: http
+
+listeners:
+  - name: llm
+    type: model
+    port: 12000
+    input_filters:
+      - input_guard
+    output_filters:
+      - missing_output_guard
+
+model_providers:
+  - model: openai/gpt-4o-mini
+    access_key: $OPENAI_API_KEY
+    default: true
+
+""",
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

Fixes #945.

This extends listener-level filter validation so `output_filters` references are checked during config generation, just like `input_filters`.

## Why

Filter chains are part of Plano's guardrails path. If an `output_filters` ID has a typo, config generation should fail early with a clear error instead of allowing the response path to continue without the intended filter.

This came up while working on a similar ingress/egress processing flow in SGLang: https://github.com/sgl-project/sglang/pull/21154

## Changes

- Validate listener-level `input_filters` and `output_filters` against defined `agents` / `filters`
- Add a config-generator regression test for an unknown `output_filters` ID

## Local Testing

Focused regression test:

```bash
cd cli
uv run pytest test/test_config_generator.py -k unknown_listener_output_filter
```

Full config-generator test file:

```bash
cd cli
uv run pytest test/test_config_generator.py
```

Result locally:

```text
21 passed
```