### PR TITLE
Support Kimi Code API for Claude Code routing

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -61,7 +61,9 @@ def apply_kimi_code_provider_defaults(model_provider: dict) -> None:
         return
     parsed = urlparse(base_url)
     model_id = model_provider.get("model", "")
-    is_kimi_code = parsed.hostname == KIMI_CODE_API_HOST or model_id == "kimi-for-coding"
+    is_kimi_code = (
+        parsed.hostname == KIMI_CODE_API_HOST or model_id == "kimi-for-coding"
+    )
     if not is_kimi_code:
         return
 
@@ -71,6 +73,7 @@ def apply_kimi_code_provider_defaults(model_provider: dict) -> None:
 
     headers = model_provider.setdefault("headers", {})
     headers.setdefault("User-Agent", KIMI_CODE_DEFAULT_USER_AGENT)
+
 
 SUPPORTED_PROVIDERS = (
     SUPPORTED_PROVIDERS_WITHOUT_BASE_URL + SUPPORTED_PROVIDERS_WITH_BASE_URL

--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -39,6 +39,39 @@ CHATGPT_API_BASE = "https://chatgpt.com/backend-api/codex"
 CHATGPT_DEFAULT_ORIGINATOR = "codex_cli_rs"
 CHATGPT_DEFAULT_USER_AGENT = "codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown"
 
+KIMI_CODE_API_HOST = "api.kimi.com"
+KIMI_CODE_DEFAULT_USER_AGENT = "KimiCLI/1.3"
+
+
+def normalize_kimi_code_base_url(base_url: str) -> str:
+    """Ensure Kimi Code API base URLs include the /v1 suffix."""
+    parsed = urlparse(base_url)
+    if parsed.hostname != KIMI_CODE_API_HOST:
+        return base_url
+    path = parsed.path.rstrip("/")
+    if path.endswith("/coding"):
+        return f"{parsed.scheme}://{parsed.netloc}{path}/v1"
+    return base_url
+
+
+def apply_kimi_code_provider_defaults(model_provider: dict) -> None:
+    """Inject Kimi Code API defaults (User-Agent, normalized base URL)."""
+    base_url = model_provider.get("base_url")
+    if not base_url:
+        return
+    parsed = urlparse(base_url)
+    model_id = model_provider.get("model", "")
+    is_kimi_code = parsed.hostname == KIMI_CODE_API_HOST or model_id == "kimi-for-coding"
+    if not is_kimi_code:
+        return
+
+    normalized = normalize_kimi_code_base_url(base_url)
+    if normalized != base_url:
+        model_provider["base_url"] = normalized
+
+    headers = model_provider.setdefault("headers", {})
+    headers.setdefault("User-Agent", KIMI_CODE_DEFAULT_USER_AGENT)
+
 SUPPORTED_PROVIDERS = (
     SUPPORTED_PROVIDERS_WITHOUT_BASE_URL + SUPPORTED_PROVIDERS_WITH_BASE_URL
 )
@@ -462,6 +495,8 @@ def validate_and_render_schema():
                 headers.setdefault("user-agent", CHATGPT_DEFAULT_USER_AGENT)
                 headers.setdefault("session_id", str(uuid.uuid4()))
                 model_provider["headers"] = headers
+
+            apply_kimi_code_provider_defaults(model_provider)
 
             updated_model_providers.append(model_provider)
 

--- a/cli/test/test_config_generator.py
+++ b/cli/test/test_config_generator.py
@@ -3,8 +3,10 @@ import pytest
 import yaml
 from unittest import mock
 from planoai.config_generator import (
-    validate_and_render_schema,
+    apply_kimi_code_provider_defaults,
     migrate_inline_routing_preferences,
+    normalize_kimi_code_base_url,
+    validate_and_render_schema,
 )
 
 
@@ -738,3 +740,29 @@ model_providers:
     migrate_inline_routing_preferences(config_yaml)
 
     assert config_yaml["version"] == "v0.5.0"
+
+
+def test_normalize_kimi_code_base_url_appends_v1_suffix():
+    assert (
+        normalize_kimi_code_base_url("https://api.kimi.com/coding")
+        == "https://api.kimi.com/coding/v1"
+    )
+    assert (
+        normalize_kimi_code_base_url("https://api.kimi.com/coding/")
+        == "https://api.kimi.com/coding/v1"
+    )
+    assert (
+        normalize_kimi_code_base_url("https://api.kimi.com/coding/v1")
+        == "https://api.kimi.com/coding/v1"
+    )
+
+
+def test_apply_kimi_code_provider_defaults_injects_user_agent():
+    provider = {
+        "model": "kimi-for-coding",
+        "base_url": "https://api.kimi.com/coding",
+        "access_key": "$MOONSHOTAI_API_KEY",
+    }
+    apply_kimi_code_provider_defaults(provider)
+    assert provider["base_url"] == "https://api.kimi.com/coding/v1"
+    assert provider["headers"]["User-Agent"] == "KimiCLI/1.3"

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -194,6 +194,7 @@ properties:
             - digitalocean
             - vercel
             - openrouter
+            - moonshotai
         headers:
           type: object
           additionalProperties:
@@ -252,6 +253,7 @@ properties:
             - digitalocean
             - vercel
             - openrouter
+            - moonshotai
         headers:
           type: object
           additionalProperties:

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
@@ -139,11 +140,30 @@ impl ChatCompletionsRequest {
 
     /// Strip request fields that Kimi Code API (`kimi-for-coding`) rejects or mishandles.
     pub fn normalize_for_kimi_code_api(&mut self) {
-        self.stream_options = None;
-        self.reasoning_effort = None;
-        self.web_search_options = None;
-        self.service_tier = None;
-        self.store = None;
+        if self.stream_options.is_some() {
+            warn!("kimi-for-coding: stripping unsupported stream_options from upstream request");
+            self.stream_options = None;
+        }
+        if self.reasoning_effort.is_some() {
+            warn!(
+                "kimi-for-coding: stripping unsupported reasoning_effort from upstream request"
+            );
+            self.reasoning_effort = None;
+        }
+        if self.web_search_options.is_some() {
+            warn!(
+                "kimi-for-coding: stripping unsupported web_search_options from upstream request"
+            );
+            self.web_search_options = None;
+        }
+        if self.service_tier.is_some() {
+            warn!("kimi-for-coding: stripping unsupported service_tier from upstream request");
+            self.service_tier = None;
+        }
+        if self.store.is_some() {
+            warn!("kimi-for-coding: stripping unsupported store from upstream request");
+            self.store = None;
+        }
     }
 }
 

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -136,6 +136,20 @@ impl ChatCompletionsRequest {
             self.temperature = Some(1.0);
         }
     }
+
+    /// Strip request fields that Kimi Code API (`kimi-for-coding`) rejects or mishandles.
+    pub fn normalize_for_kimi_code_api(&mut self) {
+        self.stream_options = None;
+        self.reasoning_effort = None;
+        self.web_search_options = None;
+        self.service_tier = None;
+        self.store = None;
+    }
+}
+
+/// True when the upstream model id is Moonshot's Kimi Code endpoint model.
+pub fn is_kimi_code_model(model: &str) -> bool {
+    model == "kimi-for-coding"
 }
 
 // ============================================================================

--- a/crates/hermesllm/src/bin/provider_models.yaml
+++ b/crates/hermesllm/src/bin/provider_models.yaml
@@ -312,6 +312,7 @@ providers:
   - deepseek/deepseek-chat
   - deepseek/deepseek-reasoner
   moonshotai:
+  - moonshotai/kimi-for-coding
   - moonshotai/kimi-k2-thinking
   - moonshotai/moonshot-v1-auto
   - moonshotai/moonshot-v1-32k-vision-preview

--- a/crates/hermesllm/src/clients/endpoints.rs
+++ b/crates/hermesllm/src/clients/endpoints.rs
@@ -500,6 +500,19 @@ mod tests {
             "/custom/api/v2/chat/completions"
         );
 
+        // Kimi Code API: base_url path prefix already includes /coding/v1
+        assert_eq!(
+            api.target_endpoint_for_provider(
+                &ProviderId::Moonshotai,
+                "/v1/messages",
+                "kimi-for-coding",
+                false,
+                Some("/coding/v1"),
+                false
+            ),
+            "/coding/v1/chat/completions"
+        );
+
         // Test Groq with custom prefix
         assert_eq!(
             api.target_endpoint_for_provider(

--- a/crates/hermesllm/src/providers/request.rs
+++ b/crates/hermesllm/src/providers/request.rs
@@ -1,5 +1,6 @@
 use crate::apis::anthropic::MessagesRequest;
 use crate::apis::openai::{is_kimi_code_model, ChatCompletionsRequest};
+use log::warn;
 
 use crate::apis::amazon_bedrock::{ConverseRequest, ConverseStreamRequest};
 use crate::apis::openai_responses::ResponsesAPIRequest;
@@ -99,7 +100,10 @@ impl ProviderRequestType {
                     req.normalize_for_kimi_code_api();
                 }
             } else if let Self::MessagesRequest(req) = self {
-                if is_kimi_code_model(req.model.as_str()) {
+                if is_kimi_code_model(req.model.as_str()) && req.thinking.is_some() {
+                    warn!(
+                        "kimi-for-coding: stripping unsupported thinking config from upstream request"
+                    );
                     req.thinking = None;
                 }
             }

--- a/crates/hermesllm/src/providers/request.rs
+++ b/crates/hermesllm/src/providers/request.rs
@@ -1,5 +1,5 @@
 use crate::apis::anthropic::MessagesRequest;
-use crate::apis::openai::ChatCompletionsRequest;
+use crate::apis::openai::{is_kimi_code_model, ChatCompletionsRequest};
 
 use crate::apis::amazon_bedrock::{ConverseRequest, ConverseStreamRequest};
 use crate::apis::openai_responses::ResponsesAPIRequest;
@@ -87,6 +87,21 @@ impl ProviderRequestType {
             if let Self::ChatCompletionsRequest(req) = self {
                 // xAI's legacy live-search shape is deprecated on chat/completions.
                 req.web_search_options = None;
+            }
+        }
+
+        if matches!(
+            upstream_api,
+            SupportedUpstreamAPIs::OpenAIChatCompletions(_)
+        ) {
+            if let Self::ChatCompletionsRequest(req) = self {
+                if is_kimi_code_model(req.model()) {
+                    req.normalize_for_kimi_code_api();
+                }
+            } else if let Self::MessagesRequest(req) = self {
+                if is_kimi_code_model(req.model.as_str()) {
+                    req.thinking = None;
+                }
             }
         }
 
@@ -876,6 +891,42 @@ mod tests {
         let ProviderRequestType::ChatCompletionsRequest(req) = request else {
             panic!("expected chat request");
         };
+        assert!(req.web_search_options.is_none());
+    }
+
+    #[test]
+    fn test_normalize_for_upstream_kimi_code_strips_unsupported_chat_fields() {
+        use crate::apis::openai::{Message, MessageContent, OpenAIApi, Role, StreamOptions};
+
+        let mut request = ProviderRequestType::ChatCompletionsRequest(ChatCompletionsRequest {
+            model: "kimi-for-coding".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Some(MessageContent::Text("hello".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            stream_options: Some(StreamOptions {
+                include_usage: Some(true),
+            }),
+            reasoning_effort: Some("high".to_string()),
+            web_search_options: Some(serde_json::json!({"search_context_size":"medium"})),
+            ..Default::default()
+        });
+
+        request
+            .normalize_for_upstream(
+                ProviderId::Moonshotai,
+                &SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
+            )
+            .unwrap();
+
+        let ProviderRequestType::ChatCompletionsRequest(req) = request else {
+            panic!("expected chat request");
+        };
+        assert!(req.stream_options.is_none());
+        assert!(req.reasoning_effort.is_none());
         assert!(req.web_search_options.is_none());
     }
 

--- a/docs/source/concepts/llm_providers/supported_providers.rst
+++ b/docs/source/concepts/llm_providers/supported_providers.rst
@@ -432,6 +432,9 @@ Moonshot AI
    * - Model Name
      - Model ID for Config
      - Description
+   * - Kimi for Coding
+     - ``moonshotai/kimi-for-coding``
+     - Kimi Code API model for agentic coding (use with ``base_url: https://api.kimi.com/coding/v1``)
    * - Kimi K2 Preview
      - ``moonshotai/kimi-k2-0905-preview``
      - Foundation model optimized for agentic tasks with 32B activated parameters
@@ -447,6 +450,13 @@ Moonshot AI
 .. code-block:: yaml
 
     llm_providers:
+      # Kimi Code API (Claude Code / agentic clients via Plano translation)
+      - model: moonshotai/kimi-for-coding
+        access_key: $MOONSHOTAI_API_KEY
+        base_url: https://api.kimi.com/coding/v1
+        headers:
+          User-Agent: "KimiCLI/1.3"
+
       # Latest K2 models for agentic tasks
       - model: moonshotai/kimi-k2-0905-preview
         access_key: $MOONSHOTAI_API_KEY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `moonshotai/kimi-for-coding` and wires Kimi Code API (`https://api.kimi.com/coding/v1`) for agentic clients like Claude Code.

**Changes**
- Register `kimi-for-coding` model; route Anthropic clients to `/coding/v1/chat/completions` via custom `base_url`
- Strip unsupported upstream fields (`stream_options`, `reasoning_effort`, etc.) for Kimi Code
- Config generator: normalize `/coding` → `/coding/v1`, default `User-Agent: KimiCLI/1.3`
- Docs + schema updates

Closes #949
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27e18a75-20ec-4520-befd-bff9bfa98e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27e18a75-20ec-4520-befd-bff9bfa98e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

