### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -400,6 +400,10 @@ pub enum LlmProviderType {
     Vercel,
     #[serde(rename = "openrouter")]
     OpenRouter,
+    #[serde(rename = "astraflow")]
+    Astraflow,
+    #[serde(rename = "astraflow_cn")]
+    AstraflowCN,
 }
 
 impl Display for LlmProviderType {
@@ -425,6 +429,8 @@ impl Display for LlmProviderType {
             LlmProviderType::DigitalOcean => write!(f, "digitalocean"),
             LlmProviderType::Vercel => write!(f, "vercel"),
             LlmProviderType::OpenRouter => write!(f, "openrouter"),
+            LlmProviderType::Astraflow => write!(f, "astraflow"),
+            LlmProviderType::AstraflowCN => write!(f, "astraflow_cn"),
         }
     }
 }

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -48,6 +48,8 @@ pub enum ProviderId {
     DigitalOcean,
     Vercel,
     OpenRouter,
+    Astraflow,
+    AstraflowCN,
 }
 
 impl TryFrom<&str> for ProviderId {
@@ -81,6 +83,8 @@ impl TryFrom<&str> for ProviderId {
             "do_ai" => Ok(ProviderId::DigitalOcean), // alias
             "vercel" => Ok(ProviderId::Vercel),
             "openrouter" => Ok(ProviderId::OpenRouter),
+            "astraflow" => Ok(ProviderId::Astraflow),
+            "astraflow_cn" => Ok(ProviderId::AstraflowCN),
             _ => Err(format!("Unknown provider: {}", value)),
         }
     }
@@ -107,6 +111,7 @@ impl ProviderId {
             ProviderId::Qwen => "qwen",
             ProviderId::ChatGPT => "chatgpt",
             ProviderId::DigitalOcean => "digitalocean",
+            ProviderId::Astraflow | ProviderId::AstraflowCN => return Vec::new(),
             _ => return Vec::new(),
         };
 
@@ -174,7 +179,9 @@ impl ProviderId {
                 | ProviderId::Qwen
                 | ProviderId::DigitalOcean
                 | ProviderId::OpenRouter
-                | ProviderId::ChatGPT,
+                | ProviderId::ChatGPT
+                | ProviderId::Astraflow
+                | ProviderId::AstraflowCN,
                 SupportedAPIsFromClient::AnthropicMessagesAPI(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -196,7 +203,9 @@ impl ProviderId {
                 | ProviderId::Qwen
                 | ProviderId::DigitalOcean
                 | ProviderId::OpenRouter
-                | ProviderId::ChatGPT,
+                | ProviderId::ChatGPT
+                | ProviderId::Astraflow
+                | ProviderId::AstraflowCN,
                 SupportedAPIsFromClient::OpenAIChatCompletions(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -267,6 +276,8 @@ impl Display for ProviderId {
             ProviderId::DigitalOcean => write!(f, "digitalocean"),
             ProviderId::Vercel => write!(f, "vercel"),
             ProviderId::OpenRouter => write!(f, "openrouter"),
+            ProviderId::Astraflow => write!(f, "astraflow"),
+            ProviderId::AstraflowCN => write!(f, "astraflow_cn"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.

Two variants are registered to cover both endpoints:

| Variant | `provider_interface` key | Endpoint |
|---|---|---|
| `Astraflow` | `astraflow` | `https://api-us-ca.umodelverse.ai/v1` (global) |
| `AstraflowCN` | `astraflow_cn` | `https://api.modelverse.cn/v1` (China) |

## Changes

### `crates/hermesllm/src/providers/id.rs`
- Added `Astraflow` and `AstraflowCN` variants to the `ProviderId` enum
- Added `"astraflow"` / `"astraflow_cn"` arms to `TryFrom<&str>`
- Added explicit `_ => return Vec::new()` arms in `models()` (no static model list needed — Astraflow supports 200+ models dynamically configured by the user)
- Added both variants to the OpenAI-compatible arms in `compatible_api_for_client()` (both `AnthropicMessagesAPI` and `OpenAIChatCompletions` translate to `OpenAIChatCompletions` upstream)
- Added `Display` arms (`"astraflow"` / `"astraflow_cn"`)

### `crates/common/src/configuration.rs`
- Added `Astraflow` and `AstraflowCN` variants to the `LlmProviderType` enum (with `serde` rename attributes)
- Added `Display` arms for both variants

## Usage example

```yaml
model_providers:
  - name: astraflow/gpt-4o
    provider_interface: astraflow
    access_key: $ASTRAFLOW_API_KEY
    endpoint: api-us-ca.umodelverse.ai
    model: gpt-4o

  - name: astraflow-cn/deepseek-v3
    provider_interface: astraflow_cn
    access_key: $ASTRAFLOW_CN_API_KEY
    endpoint: api.modelverse.cn
    model: deepseek-v3
```

## References
- Global: https://astraflow.ucloud-global.com
- China: https://astraflow.ucloud.cn
- API docs describe full OpenAI-compatible interface (`/v1/chat/completions`, etc.)
