### PR TITLE
chore: fix three typos in README + comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plano solves this by moving core delivery concerns into a unified, out-of-proces
 Plano pulls rote plumbing out of your framework so you can stay focused on what matters most: the core product logic of your agentic applications. Plano is backed by [industry-leading LLM research](https://planoai.dev/research) and built on [Envoy](https://envoyproxy.io) by its core contributors, who built critical infrastructure at scale for modern worklaods.
 
 **High-Level Network Sequence Diagram**:
-![high-level network plano arcitecture for Plano](docs/source/_static/img/plano_network_diagram_high_level.png)
+![high-level network plano architecture for Plano](docs/source/_static/img/plano_network_diagram_high_level.png)
 
 **Jump to our [docs](https://docs.planoai.dev)** to learn how you can use Plano to improve the speed, safety and obervability of your agentic applications.
 
@@ -156,7 +156,7 @@ curl http://localhost:8001/v1/chat/completions \
 
 Every request is traced end-to-end with OpenTelemetry - no instrumentation code needed.
 
-![Atomatic Tracing](docs/source/_static/img/demo_tracing.png)
+![Automatic Tracing](docs/source/_static/img/demo_tracing.png)
 
 ### What You Didn't Have to Build
 

--- a/crates/common/src/api/open_ai.rs
+++ b/crates/common/src/api/open_ai.rs
@@ -53,7 +53,7 @@ impl Serialize for FunctionParameters {
     where
         S: serde::Serializer,
     {
-        // select all requried parameters
+        // select all required parameters
         let required: Vec<&String> = self
             .properties
             .iter()


### PR DESCRIPTION
## Summary

- `README.md:35` - image alt text "arcitecture" → "architecture"
- `README.md:159` - image alt text "Atomatic Tracing" → "Automatic Tracing"
- `crates/common/src/api/open_ai.rs:56` - comment "requried parameters" → "required parameters"

Doc + comment only.