### PR TITLE
fix(ci): unbreak main — rustfmt warn! + proxy-wasm 0.2.5 for Rust 1.96

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2552,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "proxy-wasm"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d35d9e2bc5104e2e954b149aa1d5f9fa3bb27f73b45b2706020fed101db685"
+checksum = "de8f6564bd52c2f4ff79fa5d1bd3bc10d8f822162af8d527e121e46703496aa0"
 dependencies = [
  "hashbrown 0.16.1",
  "log",

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -145,9 +145,7 @@ impl ChatCompletionsRequest {
             self.stream_options = None;
         }
         if self.reasoning_effort.is_some() {
-            warn!(
-                "kimi-for-coding: stripping unsupported reasoning_effort from upstream request"
-            );
+            warn!("kimi-for-coding: stripping unsupported reasoning_effort from upstream request");
             self.reasoning_effort = None;
         }
         if self.web_search_options.is_some() {


### PR DESCRIPTION
## Summary

Fixes the two failing CI checks (`pre-commit` / cargo-fmt and `native-smoke-test`) currently red on every PR + every push to `main` since #951 / since the May 28 Rust 1.96 release.

### 1. `cargo-fmt` failure in `crates/hermesllm/src/apis/openai.rs:147`

Collapse the short `warn!(...)` call onto a single line so rustfmt is happy. The neighbouring `web_search_options` warn stays multi-line because its message + indent is just over 100 chars.

### 2. `native-smoke-test` wasm link failure: `undefined symbol: proxy_set_effective_context`

Root cause: **Rust 1.96.0 (released 2026-05-28) stopped passing `--allow-undefined` to `wasm-ld`** ([rust-lang/rust#149868](https://github.com/rust-lang/rust/issues/149868), [release notes](https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/)). Every host import declared in a plain `extern "C"` block — including all of proxy-wasm's `proxy_*` symbols — is now a hard linker error instead of being implicitly imported from the `"env"` module.

Until now we were pulling in `proxy-wasm 0.2.4` (manifest is `0.2.1`, semver-resolved to latest 0.2.x). The 0.2.5 release published on 2026-05-20 adds `#[link(wasm_import_module = "env")]` to every `extern "C"` block specifically to fix this: see [v0.2.4...v0.2.5 diff](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/compare/v0.2.4...v0.2.5) ("Fixed compatibility with Rust v1.96.0").

Fix is a one-line lockfile bump:

```
- proxy-wasm v0.2.4
+ proxy-wasm v0.2.5
```

No manifest changes needed — `"0.2.1"` already allows 0.2.5.

## Verification

Locally (rustc 1.94.0 on macOS, where the build was passing already):

```
cd crates
cargo fmt --all -- --check                                       # clean
cargo clippy --locked --all-targets --all-features -- -D warnings # clean
cargo test --lib                                                  # 156 + 6 + 4 pass
cargo build --release --target=wasm32-wasip1 -p llm_gateway -p prompt_gateway  # ok
```

CI on this PR will be the real proof since the regression is rustc-1.96-specific.

## Test plan
- [ ] CI `pre-commit` job green
- [ ] CI `native-smoke-test` job green