### PR TITLE
fix(docs): pin sphinxawesome-theme to <6.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx_copybutton==0.5.2
-sphinxawesome-theme
+sphinxawesome-theme<6.0.0
 sphinx_sitemap
 sphinx_design
-sphinxawesome_theme


### PR DESCRIPTION
`sphinxawesome-theme==6.0.3` (released June 12) restructured the package, breaking `import sphinxawesome_theme` at docs build time. Pin to `<6.0.0` to stay on the last working major version.