### PR TITLE
feat(hermesllm): add MiniMax provider

### DIFF
--- a/crates/hermesllm/src/bin/provider_models.yaml
+++ b/crates/hermesllm/src/bin/provider_models.yaml
@@ -122,6 +122,8 @@ providers:
   - google/deep-research-max-preview-04-2026
   - google/deep-research-preview-04-2026
   - google/deep-research-pro-preview-12-2025
+  minimax:
+  - minimax/MiniMax-M3
   mistralai:
   - mistralai/mistral-medium-2505
   - mistralai/mistral-medium-2508

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -50,6 +50,7 @@ pub enum ProviderId {
     OpenRouter,
     Astraflow,
     AstraflowCN,
+    Minimax,
 }
 
 impl TryFrom<&str> for ProviderId {
@@ -85,6 +86,7 @@ impl TryFrom<&str> for ProviderId {
             "openrouter" => Ok(ProviderId::OpenRouter),
             "astraflow" => Ok(ProviderId::Astraflow),
             "astraflow_cn" => Ok(ProviderId::AstraflowCN),
+            "minimax" => Ok(ProviderId::Minimax),
             _ => Err(format!("Unknown provider: {}", value)),
         }
     }
@@ -111,6 +113,7 @@ impl ProviderId {
             ProviderId::Qwen => "qwen",
             ProviderId::ChatGPT => "chatgpt",
             ProviderId::DigitalOcean => "digitalocean",
+            ProviderId::Minimax => "minimax",
             ProviderId::Astraflow | ProviderId::AstraflowCN => return Vec::new(),
             _ => return Vec::new(),
         };
@@ -181,7 +184,8 @@ impl ProviderId {
                 | ProviderId::OpenRouter
                 | ProviderId::ChatGPT
                 | ProviderId::Astraflow
-                | ProviderId::AstraflowCN,
+                | ProviderId::AstraflowCN
+                | ProviderId::Minimax,
                 SupportedAPIsFromClient::AnthropicMessagesAPI(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -205,7 +209,8 @@ impl ProviderId {
                 | ProviderId::OpenRouter
                 | ProviderId::ChatGPT
                 | ProviderId::Astraflow
-                | ProviderId::AstraflowCN,
+                | ProviderId::AstraflowCN
+                | ProviderId::Minimax,
                 SupportedAPIsFromClient::OpenAIChatCompletions(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -278,6 +283,7 @@ impl Display for ProviderId {
             ProviderId::OpenRouter => write!(f, "openrouter"),
             ProviderId::Astraflow => write!(f, "astraflow"),
             ProviderId::AstraflowCN => write!(f, "astraflow_cn"),
+            ProviderId::Minimax => write!(f, "minimax"),
         }
     }
 }
@@ -451,6 +457,46 @@ mod tests {
     fn test_vercel_and_openrouter_empty_models() {
         assert!(ProviderId::Vercel.models().is_empty());
         assert!(ProviderId::OpenRouter.models().is_empty());
+    }
+
+    #[test]
+    fn test_minimax_parsing_and_models() {
+        assert_eq!(ProviderId::try_from("minimax"), Ok(ProviderId::Minimax));
+        assert_eq!(ProviderId::Minimax.to_string(), "minimax");
+
+        let models = ProviderId::Minimax.models();
+        assert!(
+            models.iter().any(|m| m == "MiniMax-M3"),
+            "minimax models should include MiniMax-M3"
+        );
+        for model in &models {
+            assert!(
+                !model.contains('/'),
+                "Model name '{}' should not contain provider prefix",
+                model
+            );
+        }
+    }
+
+    #[test]
+    fn test_minimax_compatible_api() {
+        use crate::clients::endpoints::{SupportedAPIsFromClient, SupportedUpstreamAPIs};
+
+        let openai_client =
+            SupportedAPIsFromClient::OpenAIChatCompletions(OpenAIApi::ChatCompletions);
+        let upstream = ProviderId::Minimax.compatible_api_for_client(&openai_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "minimax should map OpenAI client to OpenAIChatCompletions upstream"
+        );
+
+        let anthropic_client =
+            SupportedAPIsFromClient::AnthropicMessagesAPI(AnthropicApi::Messages);
+        let upstream = ProviderId::Minimax.compatible_api_for_client(&anthropic_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "minimax should translate Anthropic client to OpenAIChatCompletions upstream"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add MiniMax (minimax) as a new LLM provider in hermesllm, compatible with the existing OpenAI-compatible provider architecture.

## Changes
- Add `Minimax` variant to the `ProviderId` enum
- Parse `"minimax"` in the `TryFrom<&str>` impl and render it in `Display`
- Map the provider to its `provider_models.yaml` key in `models()`
- Route it through OpenAI Chat Completions in `compatible_api_for_client` (same as Deepseek/Groq), for both OpenAI and Anthropic client APIs
- Add a `minimax` block with `MiniMax-M3` to `provider_models.yaml`
- Add unit tests for parsing, model listing, and API compatibility

## Testing
- `cd crates && cargo test --lib -p hermesllm providers::id` passing
