### PR TITLE
fix(docker): remove curl to drop vulnerable libssh2 transitive dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ FROM python:3.14-slim AS arch
 RUN set -eux; \
   apt-get update; \
   apt-get upgrade -y; \
-  apt-get install -y --no-install-recommends gettext-base curl procps; \
+  apt-get install -y --no-install-recommends gettext-base procps; \
   apt-get clean; rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir supervisor


### PR DESCRIPTION
## Summary

- `libssh2-1t64` was flagged by our image scanner (CVE-2026-55199, CVE-2026-55200, CVE-2026-7598) but is **not used by any Plano code**. It entered the runtime image (`python:3.14-slim` = Debian 13 "trixie") purely as a transitive dependency of `curl`: `curl → libcurl4t64 → libssh2-1t64`.
- Nothing in the container runtime uses `curl` — config generation, brightstaff, envoy, and supervisord never call it, and the CLI's health check runs from the host via Python `requests`.
- Removing `curl` from the final image eliminates `curl`, `libcurl4t64`, and `libssh2-1t64` entirely, closing all three CVEs and any future libssh2/libcurl issues.

## Notes

- Verified none of the shipped compose files using `katanemo/plano` (`tests/e2e`, `tests/archgw`, `config/docker-compose.dev.yaml`, `demos/.../plano-deployment.yaml`) rely on a curl-based container healthcheck.
- Docs/skills contain *example* `docker-compose` healthchecks using `curl` inside the container; those examples would need a curl-free alternative (follow-up, not blocking).

## Test plan

- [ ] Rebuild image and confirm scanner no longer reports libssh2/libcurl CVEs
- [ ] `plano up` / health check still works (host-side `requests`-based)