### PR TITLE
docs: add Claude Code routing via CLIProxyAPI demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -16,6 +16,7 @@ This directory contains demos showcasing Plano's capabilities as an AI-native pr
 | [Preference-Based Routing](llm_routing/preference_based_routing/) | Routes prompts to LLMs based on user-defined preferences and task type (e.g. code generation vs. understanding) |
 | [Model Alias Routing](llm_routing/model_alias_routing/) | Maps semantic aliases (`arch.summarize.v1`) to provider-specific models for centralized governance |
 | [Claude Code Router](llm_routing/claude_code_router/) | Extends Claude Code with multi-provider access and preference-aligned routing for coding tasks |
+| [Claude Code via CLIProxyAPI](llm_routing/claude_code_cliproxy/) | Routes Claude Code across Codex subscription models through a local Anthropic-compatible CLIProxyAPI upstream |
 | [Codex Router](llm_routing/codex_router/) | Extends Codex CLI with multi-provider access and preference-aligned routing for coding tasks |
 
 ## Agent Orchestration

--- a/demos/llm_routing/claude_code_cliproxy/README.md
+++ b/demos/llm_routing/claude_code_cliproxy/README.md
@@ -1,0 +1,432 @@
+# Claude Code → Plano → CLIProxyAPI (Codex OAuth)
+
+This demo routes Claude Code through Plano's hosted preference router, then forwards the selected Anthropic-protocol request to a local [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) process backed by a Codex OAuth subscription.
+
+It is intentionally self-contained and secret-free. The checked-in files contain no OAuth credentials or usable API keys.
+
+## Architecture
+
+```text
+Claude Code
+  │ Anthropic Messages API (/v1/messages)
+  │ model aliases: fable / opus / sonnet / haiku
+  ▼
+Plano on 127.0.0.1:12000
+  │ hosted preference classification
+  ├─ diagnosis-only deep reasoning ──▶ Sol
+  ├─ implementation/review/testing ─▶ Terra
+  └─ small lookup/format/summary ────▶ Luna
+  │ Anthropic Messages API
+  ▼
+CLIProxyAPI on 127.0.0.1:8317
+  │ validates a local static API key
+  │ owns Codex OAuth credentials and protocol translation
+  ▼
+Codex subscription backend
+```
+
+The boundaries are deliberate:
+
+- **Claude Code** speaks the Anthropic Messages protocol.
+- **Plano** owns hosted preference classification, model aliases, and provider selection.
+- **CLIProxyAPI** owns Codex OAuth and Anthropic-to-Codex compatibility. Plano does not receive the OAuth token.
+- **The upstream provider** ultimately determines model availability, context limits, quotas, and subscription policy.
+
+## Versions tested
+
+This path was tested with Plano 0.4.27 and CLIProxyAPI 7.2.70.
+
+| Component   | Version     |
+| ----------- | ----------- |
+| Plano       | **0.4.27**  |
+| CLIProxyAPI | **7.2.70**  |
+| Claude Code | **2.1.209** |
+
+CLIProxyAPI **7.2.75** was the latest release researched on 2026-07-14. It is not required by this demo; use it only after reviewing its release notes and rerunning the included tests.
+
+## Prerequisites
+
+- macOS with [Homebrew](https://brew.sh/) for the exact CLIProxyAPI service commands below. Other platforms can use the [official CLIProxyAPI quick start](https://help.router-for.me/introduction/quick-start).
+- [uv](https://docs.astral.sh/uv/) for the pinned Plano CLI installation.
+- Node.js and npm for Claude Code.
+- `bash`, `curl`, and `lsof`.
+- Ruby with Psych and JSON support. The launcher uses it to read `api-keys[0]` when needed and validate CLIProxyAPI's model catalog.
+- A Codex-capable account whose plan and applicable terms permit this use.
+
+## 1. Install the CLIs
+
+```bash
+brew install cliproxyapi
+uv tool install 'planoai==0.4.27'
+npm install -g @anthropic-ai/claude-code
+
+planoai --version
+cliproxyapi --version
+claude --version
+```
+
+If `planoai` is already installed with `uv tool`, reinstall the pinned version with:
+
+```bash
+uv tool install --force 'planoai==0.4.27'
+```
+
+## 2. Configure CLIProxyAPI locally
+
+Homebrew's default config path is `$(brew --prefix)/etc/cliproxyapi.conf`, and the launcher autodetects that path. Outside Homebrew, set `CLIPROXY_CONFIG` explicitly; the launcher does not guess a non-Homebrew config location. An already-exported `CLIPROXY_LOCAL_API_KEY` bypasses config-file key extraction.
+
+The following creates a backup, installs the local-only template, generates a random client key, and writes the key without putting it in the repository:
+
+```bash
+CLIPROXY_CONFIG="$(brew --prefix)/etc/cliproxyapi.conf"
+
+brew services stop cliproxyapi 2>/dev/null || true
+if [[ -f "$CLIPROXY_CONFIG" ]]; then
+  cp -p "$CLIPROXY_CONFIG" "${CLIPROXY_CONFIG}.backup"
+fi
+install -m 600 cliproxyapi.conf.example "$CLIPROXY_CONFIG"
+
+export CLIPROXY_LOCAL_API_KEY="$(openssl rand -hex 32)"
+ruby -rpsych -e '
+  path = ARGV.fetch(0)
+  config = Psych.safe_load_file(path, permitted_classes: [], permitted_symbols: [], aliases: false)
+  config["api-keys"] = [ENV.fetch("CLIPROXY_LOCAL_API_KEY")]
+  File.write(path, Psych.dump(config))
+' "$CLIPROXY_CONFIG"
+unset CLIPROXY_LOCAL_API_KEY
+chmod 600 "$CLIPROXY_CONFIG"
+```
+
+If this machine already has a customized CLIProxyAPI config, merge these fields instead of replacing the file:
+
+```yaml
+host: 127.0.0.1
+port: 8317
+remote-management:
+  allow-remote: false
+  secret-key: ""
+  disable-control-panel: true
+api-keys:
+  - "<random local client key>"
+```
+
+An empty `remote-management.secret-key` disables the Management API. `disable-control-panel: true` separately disables the bundled control panel.
+
+## 3. Authenticate CLIProxyAPI with Codex OAuth
+
+Run the upstream login flow. It opens the provider authorization page and stores the resulting credential under CLIProxyAPI's auth directory; it does not write the OAuth token into this demo.
+
+```bash
+cliproxyapi --codex-login
+```
+
+For a headless machine, consult `cliproxyapi --help` and the [CLIProxyAPI documentation](https://help.router-for.me/) for the no-browser login option.
+
+Start the local service:
+
+```bash
+brew services start cliproxyapi
+brew services list | grep cliproxyapi
+lsof -nP -iTCP:8317 -sTCP:LISTEN
+```
+
+Verify authentication without printing the local key:
+
+```bash
+CLIPROXY_CONFIG="$(brew --prefix)/etc/cliproxyapi.conf"
+CLIPROXY_LOCAL_API_KEY="$(ruby -rpsych -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), permitted_classes: [], permitted_symbols: [], aliases: false)
+  print config.fetch("api-keys").fetch(0)
+' "$CLIPROXY_CONFIG")"
+
+printf 'Authorization: Bearer %s\n' "$CLIPROXY_LOCAL_API_KEY" | \
+  curl -q --noproxy '*' --fail --silent --show-error \
+    --header @- http://127.0.0.1:8317/v1/models
+```
+
+CLIProxyAPI accepts the Anthropic `/v1/messages` endpoint with either `Authorization: Bearer …` or `x-api-key`. The launcher uses bearer authentication between Claude Code and Plano; Plano replaces that placeholder credential with `CLIPROXY_LOCAL_API_KEY` for the local upstream.
+
+## 4. Validate the templates
+
+The structural validator reads YAML only. The test suite uses command mocks. Neither command starts CLIProxyAPI or Plano, contacts Plano's hosted router, or runs inference.
+
+```bash
+ruby validate_configs.rb config.yaml cliproxyapi.conf.example
+bash test.sh
+```
+
+The checked-in Plano config can also be checked with Plano's repository validator from this demo directory:
+
+```bash
+bash ../../../config/validate_plano_config.sh
+```
+
+## 5. Start Plano, then launch Claude Code
+
+The launcher is preflight-only. It never calls `planoai up` or `planoai down`, and it does not create PID files, locks, state, or background processes. Start both services explicitly before invoking it.
+
+CLIProxyAPI should already be running from step 3. Load its local client key without printing it, then start Plano:
+
+```bash
+CLIPROXY_CONFIG="$(brew --prefix)/etc/cliproxyapi.conf"
+CLIPROXY_LOCAL_API_KEY="$(ruby -rpsych -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), permitted_classes: [], permitted_symbols: [], aliases: false)
+  print config.fetch("api-keys").fetch(0)
+' "$CLIPROXY_CONFIG")"
+
+umask 077
+BIND_ADDRESS=127.0.0.1:9091 \
+METRICS_BIND_ADDRESS=127.0.0.1:9092 \
+CLIPROXY_LOCAL_API_KEY="$CLIPROXY_LOCAL_API_KEY" \
+  planoai up config.yaml
+```
+
+`BIND_ADDRESS` and `METRICS_BIND_ADDRESS` constrain Brightstaff's native control and metrics listeners. `umask 077` protects newly created native runtime files that contain the rendered provider credential. In Plano 0.4.27 native mode, Envoy's unauthenticated admin listener is still generated on `0.0.0.0:9901`, and its config dump can expose rendered provider configuration. Treat native mode as a local development convenience, apply host firewall controls, inspect existing `~/.plano/run` permissions if Plano has already run, and rotate the local key after suspected exposure. For production, use Docker or another isolated deployment boundary with explicit port publishing, secret mounts, and no externally reachable admin surface.
+
+After both health checks pass, launch Claude Code:
+
+```bash
+chmod +x claude-plano
+CLIPROXY_CONFIG="$CLIPROXY_CONFIG" ./claude-plano
+```
+
+The launcher verifies that CLIProxyAPI is listening only on loopback, performs an authenticated `GET /v1/models`, requires the Sol, Terra, and Luna model IDs, checks Plano's `/healthz`, removes `CLIPROXY_LOCAL_API_KEY` from Claude's environment, and then replaces itself with Claude Code. It never adds `--dangerously-skip-permissions`; normal Claude Code permission controls remain active.
+
+To install the launcher separately from the demo, copy the config and launcher, start Plano explicitly with the copied config, and point the launcher at the active services:
+
+```bash
+mkdir -p "$HOME/.config/claude-plano" "$HOME/.local/bin"
+install -m 600 config.yaml "$HOME/.config/claude-plano/config.yaml"
+install -m 755 claude-plano "$HOME/.local/bin/claude-plano"
+
+umask 077
+BIND_ADDRESS=127.0.0.1:9091 \
+METRICS_BIND_ADDRESS=127.0.0.1:9092 \
+CLIPROXY_LOCAL_API_KEY="$CLIPROXY_LOCAL_API_KEY" \
+  planoai up "$HOME/.config/claude-plano/config.yaml"
+
+CLIPROXY_CONFIG="$CLIPROXY_CONFIG" \
+  "$HOME/.local/bin/claude-plano"
+```
+
+### Launcher overrides
+
+| Variable                    | Default                                  | Purpose                                                                  |
+| --------------------------- | ---------------------------------------- | ------------------------------------------------------------------------ |
+| `CLIPROXY_URL`              | `http://127.0.0.1:8317`                  | CLIProxyAPI base URL and listener port                                   |
+| `CLIPROXY_CONFIG`           | Homebrew config path; otherwise required | Active CLIProxyAPI config used only when the key is not already exported |
+| `CLIPROXY_LOCAL_API_KEY`    | Read from `api-keys[0]` with Ruby/Psych  | Existing local client key or secret-manager injection                    |
+| `PLANO_URL`                 | `http://127.0.0.1:12000`                 | Running Plano base URL                                                   |
+| `PLANO_CLIENT_AUTH_TOKEN`   | `local-plano-proxy`                      | Nonsecret bearer token Claude Code sends to local Plano                  |
+| `CLAUDE_PLANO_MODEL`        | `opus`                                   | Initial Claude Code alias; may be `opus[1m]`                             |
+| `CLAUDE_PLANO_FABLE_MODEL`  | `claude-fable-5`                         | Full model name used to resolve the `fable` alias                        |
+| `CLAUDE_PLANO_OPUS_MODEL`   | `claude-opus-4-8`                        | Full model name used to resolve `opus` and Fable's automatic fallback    |
+| `CLAUDE_PLANO_SONNET_MODEL` | `claude-sonnet-5`                        | Full model name used to resolve the `sonnet` alias                       |
+| `CLAUDE_PLANO_HAIKU_MODEL`  | `claude-haiku-4-5`                       | Full model name used for `haiku` and Claude Code background work         |
+| `CLAUDE_BIN`                | `claude`                                 | Claude Code executable                                                   |
+| `RUBY_BIN`                  | `ruby`                                   | Ruby executable                                                          |
+| `CURL_BIN`                  | `curl`                                   | curl executable                                                          |
+| `LSOF_BIN`                  | `lsof`                                   | lsof executable                                                          |
+
+All arguments are forwarded to Claude Code unchanged, for example:
+
+```bash
+./claude-plano --print "Summarize this repository in five bullets."
+```
+
+## Model aliases and the context boundary
+
+Plano model names include a protocol prefix:
+
+- `anthropic/gpt-5.6-sol`
+- `anthropic/gpt-5.6-terra`
+- `anthropic/gpt-5.6-luna`
+
+The `anthropic/` segment tells Plano to use the Anthropic Messages protocol. The public model IDs sent on the upstream wire are the unsuffixed `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` IDs.
+
+The launcher starts Claude Code with `ANTHROPIC_MODEL=opus` by default and pins each Claude family alias to a full Claude model name. Plano then translates those full names through `model_aliases`:
+
+| Claude Code alias | Full name seen by Plano | Plano target | Role                            |
+| ----------------- | ----------------------- | ------------ | ------------------------------- |
+| `fable`           | `claude-fable-5`        | Sol          | Deep diagnosis and architecture |
+| `opus`            | `claude-opus-4-8`       | Terra        | Default implementation tier     |
+| `sonnet`          | `claude-sonnet-5`       | Luna         | Fast general tier               |
+| `haiku`           | `claude-haiku-4-5`      | Luna         | Background and small tasks      |
+
+Keeping full Claude family names at the client boundary is deliberate. Claude Code uses `ANTHROPIC_DEFAULT_FABLE_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL` both for alias resolution and to recognize the Fable-to-Opus automatic fallback. In this demo, a classifier-flagged interactive Fable request can therefore fall back from Sol to Terra. Non-interactive Claude Code cannot show the fallback prompt and may end the turn with a refusal. The family variables are not a general provider failover chain: Sonnet and Haiku do not automatically fall back through the other aliases.
+
+Claude Code also understands the optional client annotation `opus[1m]`. If desired, use it only at the Claude Code boundary:
+
+```bash
+CLAUDE_PLANO_MODEL='opus[1m]' ./claude-plano
+```
+
+Claude Code strips `[1m]` before sending the model name to the gateway. It is **not** a CLIProxyAPI or Plano model ID and must never appear in `model_providers`, `routing_preferences`, or alias targets. The annotation asks the client to budget for an extended context window; it does not create capacity in CLIProxyAPI, Codex, or the subscription backend, and this demo does **not** promise a one-million-token context. Actual behavior depends on the client version, gateway translation, selected upstream model, and account entitlement.
+
+## Route behavior
+
+The three descriptions are written to be mutually exclusive:
+
+1. **`deep-technical-reasoning` → Sol**: diagnosis-only root-cause, concurrency, architecture, security, or incident analysis; excludes writing, review, and testing.
+2. **`software-implementation` → Terra**: nontrivial writing, modification, refactoring, review, or testing; excludes diagnosis-only and trivial work.
+3. **`quick-developer-utility` → Luna**: short lookup, simple summary, trivial formatting, or renaming; explicitly excludes debugging, architecture, security, review, testing, and implementation.
+
+Terra is the default provider if a request reaches provider resolution without a preference selection. A hosted-classifier error is surfaced as an error; it is not silently treated as a successful route.
+
+## Verify routing
+
+Check local health:
+
+```bash
+printf 'Authorization: Bearer %s\n' "$CLIPROXY_LOCAL_API_KEY" | \
+  curl -q --noproxy '*' --fail --silent --show-error \
+    --header @- http://127.0.0.1:8317/v1/models >/dev/null
+plano_status=$(curl -q --noproxy '*' --silent --show-error \
+  --output /dev/null --write-out '%{http_code}' \
+  http://127.0.0.1:12000/healthz)
+[[ $plano_status == 200 ]]
+```
+
+Watch Plano's native logs in a second terminal:
+
+```bash
+planoai logs --debug --follow
+```
+
+Then exercise each preference:
+
+```bash
+./claude-plano --print "Diagnose the likely root cause of a distributed deadlock. Do not write or modify code."
+./claude-plano --print "Implement a tested parser for this repository and update the relevant files."
+./claude-plano --print "Summarize the current directory in three short bullets."
+```
+
+Verify the selected provider in Plano's logs. Do not infer routing from tone, latency, or response style.
+
+For a direct protocol smoke test through Plano:
+
+```bash
+curl -q --noproxy '*' --fail --silent --show-error \
+  http://127.0.0.1:12000/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'Authorization: Bearer local-plano-proxy' \
+  --data '{
+    "model": "claude-opus-4-8",
+    "max_tokens": 64,
+    "messages": [{"role": "user", "content": "Reply with exactly: routed"}]
+  }'
+```
+
+## Troubleshooting
+
+### `CLIProxyAPI is not listening`
+
+```bash
+brew services list | grep cliproxyapi
+brew services restart cliproxyapi
+lsof -nP -iTCP:8317 -sTCP:LISTEN
+```
+
+Check CLIProxyAPI logs and rerun `cliproxyapi --codex-login` if its OAuth credential expired or was revoked.
+
+### Ruby is unavailable
+
+Ruby is required even when `CLIPROXY_LOCAL_API_KEY` is already set because the launcher parses and validates the JSON returned by `/v1/models`. Install Ruby or point `RUBY_BIN` at a compatible executable.
+
+### `CLIProxyAPI listener must be loopback-only`
+
+Inspect the active socket:
+
+```bash
+lsof -nP -iTCP:8317 -sTCP:LISTEN
+```
+
+A `*:8317`, `0.0.0.0:8317`, or non-loopback address is rejected. Set `host: 127.0.0.1` in the active CLIProxyAPI config and restart the service.
+
+### `Plano health check failed`
+
+The launcher does not start or restart Plano. Start it explicitly with the command in step 5, then verify:
+
+```bash
+plano_status=$(curl -q --noproxy '*' --silent --show-error \
+  --output /dev/null --write-out '%{http_code}' \
+  http://127.0.0.1:12000/healthz)
+[[ $plano_status == 200 ]]
+```
+
+### `model not found` or an unexpected tier
+
+- Confirm `/v1/models` on CLIProxyAPI includes the required GPT tier.
+- Keep `[1m]` out of the Plano and CLIProxyAPI model IDs.
+- Run `ruby validate_configs.rb config.yaml cliproxyapi.conf.example`.
+- Confirm `CLIPROXY_CONFIG` points at the same config used by the running service.
+- Inspect `planoai logs --debug --follow` for the selected provider and upstream response.
+
+### Claude Code asks for a login
+
+Launch through `claude-plano`, which sets both `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` before Claude Code starts. A base URL by itself is not a credential.
+
+### Hosted routing is unavailable
+
+Use one of the bypass options below. The local CLIProxyAPI service and its OAuth state are independent of Plano's hosted classifier.
+
+## Rollback and direct bypass
+
+Stop Plano without changing CLIProxyAPI:
+
+```bash
+planoai down
+```
+
+Bypass Plano and send Claude Code directly to local CLIProxyAPI:
+
+```bash
+CLIPROXY_LOCAL_API_KEY='<local key from your secret store>'
+ANTHROPIC_BASE_URL=http://127.0.0.1:8317 \
+ANTHROPIC_AUTH_TOKEN="$CLIPROXY_LOCAL_API_KEY" \
+ANTHROPIC_MODEL=gpt-5.6-terra \
+ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-5.6-sol \
+ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-5.6-terra \
+ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.6-luna \
+ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.6-luna \
+  claude
+```
+
+This bypass uses CLIProxyAPI's real model IDs because Plano's aliases are no longer in the path. The family variables still define Claude Code's `fable`, `opus`, `sonnet`, and `haiku` selections; they also let the client recognize the direct Sol-to-Terra Fable fallback.
+
+To bypass both local gateways and return to Claude Code's normal configured provider, start a clean shell or unset the gateway variables:
+
+```bash
+unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_MODEL
+unset ANTHROPIC_DEFAULT_FABLE_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL
+unset ANTHROPIC_DEFAULT_SONNET_MODEL ANTHROPIC_DEFAULT_HAIKU_MODEL
+claude
+```
+
+## Privacy, terms, and security
+
+- Request content traverses local Plano and local CLIProxyAPI. The hosted Plano preference service receives the conversational text needed to classify the route. Review Plano's current privacy, retention, and service terms before using sensitive material.
+- The selected Codex backend receives the request content. Use the OAuth integration only where the account plan, provider terms, organizational policy, and applicable law permit it.
+- CLIProxyAPI credentials are stored in its auth directory. Keep that directory and the active config owner-readable only, back them up carefully, and rotate credentials after suspected exposure.
+- Keep the CLIProxyAPI and Plano data listeners on loopback. Do not publish ports `8317`, `12000`, `9091`, or `9092` to a LAN or the internet. Native Plano's Envoy admin listener on `9901` is the caveat described in step 5.
+- The local API key is a bearer credential. Never commit it, pass it on a command line that exposes process arguments, enable shell tracing around it, or paste it into logs.
+- The launcher passes the key to curl through standard input, uses it only for the authenticated preflight, and unsets `CLIPROXY_LOCAL_API_KEY` before executing Claude Code.
+- CLIProxyAPI is MIT-licensed. This demo links to the upstream project and documentation rather than copying its source or license.
+
+## Docker and production hardening
+
+This local developer demo is not a production deployment recipe. For production, run Plano and CLIProxyAPI in separately hardened containers or hosts, pin versions or image digests, run as non-root, use read-only root filesystems where possible, drop Linux capabilities, apply CPU/memory/process limits, isolate networks, mount credentials read-only from a secret manager, redact request logs, and add health/readiness monitoring.
+
+Remember that `127.0.0.1` is container-local: publishing a container port can still expose it externally. Avoid publishing the CLIProxyAPI management surface, keep management disabled, and add authenticated TLS at any boundary that is not strictly local. Reassess hosted-routing privacy, account terms, retention, and failure behavior before handling production or regulated data.
+
+## Upstream references
+
+- [Plano documentation](https://docs.planoai.dev/)
+- [Plano Claude Code router demo](../claude_code_router/)
+- [CLIProxyAPI repository](https://github.com/router-for-me/CLIProxyAPI) — MIT
+- [CLIProxyAPI documentation](https://help.router-for.me/)
+- [CLIProxyAPI quick start](https://help.router-for.me/introduction/quick-start)
+- [CLIProxyAPI Claude Code client guide](https://help.router-for.me/agent-client/claude-code)
+- [Claude Code model configuration](https://code.claude.com/docs/en/model-config)
+- [Claude Code LLM gateway connection guide](https://code.claude.com/docs/en/llm-gateway-connect)

--- a/demos/llm_routing/claude_code_cliproxy/claude-plano
+++ b/demos/llm_routing/claude_code_cliproxy/claude-plano
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLIPROXY_URL="${CLIPROXY_URL:-http://127.0.0.1:8317}"
+PLANO_URL="${PLANO_URL:-http://127.0.0.1:12000}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+RUBY_BIN="${RUBY_BIN:-ruby}"
+CURL_BIN="${CURL_BIN:-curl}"
+LSOF_BIN="${LSOF_BIN:-lsof}"
+cliproxy_key="${CLIPROXY_LOCAL_API_KEY:-}"
+export -n cliproxy_key
+set +a
+unset CLIPROXY_LOCAL_API_KEY
+
+fail() {
+  printf 'claude-plano: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+url_endpoint() {
+  "$RUBY_BIN" -ruri -e '
+    uri = URI(ARGV.fetch(0))
+    abort unless uri.is_a?(URI::HTTP) && uri.host && uri.userinfo.nil?
+    abort unless ["", "/"].include?(uri.path) && uri.query.nil? && uri.fragment.nil?
+    print "#{uri.host}\t#{uri.port}"
+  ' "$1" 2>/dev/null
+}
+
+read_cliproxy_key() {
+  if [[ -n $cliproxy_key ]]; then
+    return 0
+  fi
+
+  if [[ -z ${CLIPROXY_CONFIG:-} ]]; then
+    command -v brew >/dev/null 2>&1 ||
+      fail 'CLIPROXY_CONFIG is required outside a Homebrew installation'
+    CLIPROXY_CONFIG="$(brew --prefix)/etc/cliproxyapi.conf"
+  fi
+  [[ -f $CLIPROXY_CONFIG ]] || fail "CLIProxyAPI config not found: $CLIPROXY_CONFIG"
+
+  if ! cliproxy_key=$(
+    "$RUBY_BIN" -rpsych -e '
+      config = Psych.safe_load_file(ARGV.fetch(0), permitted_classes: [], permitted_symbols: [], aliases: false)
+      keys = config.is_a?(Hash) ? config["api-keys"] : nil
+      key = keys.is_a?(Array) ? keys.first.to_s.strip : ""
+      abort if key.empty?
+      print key
+    ' "$CLIPROXY_CONFIG" 2>/dev/null
+  ); then
+    fail 'Unable to read CLIProxyAPI api-keys[0]; set CLIPROXY_LOCAL_API_KEY instead'
+  fi
+}
+
+verify_loopback_listener() {
+  local output=$1
+  local port=$2
+  local line
+  local found=false
+
+  while IFS= read -r line; do
+    case $line in
+      n127.0.0.1:"$port" | 'n[::1]':"$port") found=true ;;
+      n*) fail "CLIProxyAPI listener must be loopback-only, found ${line#n}" ;;
+    esac
+  done <<<"$output"
+  [[ $found == true ]] || fail "CLIProxyAPI is not listening on loopback port $port"
+}
+
+verify_required_models() {
+  local models_json=$1
+  local missing
+
+  if ! missing=$(
+    "$RUBY_BIN" -rjson -e '
+      payload = JSON.parse(STDIN.read)
+      data = payload.is_a?(Hash) ? payload["data"] : nil
+      abort unless data.is_a?(Array)
+      ids = data.each_with_object([]) { |entry, found| found << entry["id"] if entry.is_a?(Hash) }
+      required = %w[gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna]
+      print((required - ids).join("\n"))
+    ' <<<"$models_json" 2>/dev/null
+  ); then
+    fail 'CLIProxyAPI returned an invalid /v1/models response'
+  fi
+  [[ -z $missing ]] || fail "CLIProxyAPI missing required model: ${missing%%$'\n'*}"
+}
+
+for command_name in "$CLAUDE_BIN" "$RUBY_BIN" "$CURL_BIN" "$LSOF_BIN"; do
+  require_command "$command_name"
+done
+
+cliproxy_endpoint=$(url_endpoint "$CLIPROXY_URL") || fail "Invalid CLIProxyAPI URL: $CLIPROXY_URL"
+IFS=$'\t' read -r cliproxy_host cliproxy_port <<<"$cliproxy_endpoint"
+case $cliproxy_host in
+  127.0.0.1 | ::1 | '[::1]' | localhost) ;;
+  *) fail "CLIProxyAPI URL must use a loopback host: $CLIPROXY_URL" ;;
+esac
+plano_endpoint=$(url_endpoint "$PLANO_URL") || fail "Invalid Plano URL: $PLANO_URL"
+IFS=$'\t' read -r plano_host _ <<<"$plano_endpoint"
+case $plano_host in 127.0.0.1 | ::1 | '[::1]' | localhost) ;; *) fail "Plano URL must use a loopback host: $PLANO_URL" ;; esac
+
+read_cliproxy_key
+listener_output=$(
+  "$LSOF_BIN" -nP -iTCP:"$cliproxy_port" -sTCP:LISTEN -Fn 2>/dev/null
+) || fail "CLIProxyAPI is not listening on loopback port $cliproxy_port"
+verify_loopback_listener "$listener_output" "$cliproxy_port"
+
+if ! models_json=$(
+  printf 'Authorization: Bearer %s\n' "$cliproxy_key" |
+    "$CURL_BIN" -q --noproxy '*' --fail --silent --show-error --max-time 5 \
+      --header @- "${CLIPROXY_URL%/}/v1/models"
+); then
+  fail 'CLIProxyAPI authentication or model discovery failed'
+fi
+verify_required_models "$models_json"
+
+plano_status=$("$CURL_BIN" -q --noproxy '*' --silent --show-error --max-time 5 \
+  --output /dev/null --write-out '%{http_code}' "${PLANO_URL%/}/healthz") ||
+  fail 'Plano health check failed'
+[[ $plano_status == 200 ]] || fail "Plano health check failed with HTTP $plano_status"
+
+unset ANTHROPIC_API_KEY
+export ANTHROPIC_BASE_URL="${PLANO_URL%/}"
+export ANTHROPIC_AUTH_TOKEN="${PLANO_CLIENT_AUTH_TOKEN:-local-plano-proxy}"
+export ANTHROPIC_MODEL="${CLAUDE_PLANO_MODEL:-opus}"
+export ANTHROPIC_DEFAULT_FABLE_MODEL="${CLAUDE_PLANO_FABLE_MODEL:-claude-fable-5}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="${CLAUDE_PLANO_OPUS_MODEL:-claude-opus-4-8}"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="${CLAUDE_PLANO_SONNET_MODEL:-claude-sonnet-5}"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="${CLAUDE_PLANO_HAIKU_MODEL:-claude-haiku-4-5}"
+
+unset cliproxy_key CLIPROXY_LOCAL_API_KEY
+exec "$CLAUDE_BIN" "$@"

--- a/demos/llm_routing/claude_code_cliproxy/cliproxyapi.conf.example
+++ b/demos/llm_routing/claude_code_cliproxy/cliproxyapi.conf.example
@@ -1,0 +1,25 @@
+# CLIProxyAPI local-only example. Copy this file to the active config path,
+# replace the placeholder with a random local key, and keep permissions at 0600.
+host: 127.0.0.1
+port: 8317
+
+tls:
+  enable: false
+  cert: ""
+  key: ""
+
+remote-management:
+  allow-remote: false
+  # An empty secret key disables all /v0/management routes.
+  secret-key: ""
+  disable-control-panel: true
+
+auth-dir: "~/.cli-proxy-api"
+
+api-keys:
+  - "replace-with-a-random-local-key"
+
+debug: false
+logging-to-file: false
+usage-statistics-enabled: false
+ws-auth: true

--- a/demos/llm_routing/claude_code_cliproxy/config.yaml
+++ b/demos/llm_routing/claude_code_cliproxy/config.yaml
@@ -1,0 +1,47 @@
+version: v0.4.0
+
+listeners:
+  - type: model
+    name: claude_code_clipproxy
+    address: 127.0.0.1
+    port: 12000
+
+model_providers:
+  - model: anthropic/gpt-5.6-sol
+    base_url: http://127.0.0.1:8317
+    access_key: $CLIPROXY_LOCAL_API_KEY
+
+  - model: anthropic/gpt-5.6-terra
+    base_url: http://127.0.0.1:8317
+    access_key: $CLIPROXY_LOCAL_API_KEY
+    default: true
+
+  - model: anthropic/gpt-5.6-luna
+    base_url: http://127.0.0.1:8317
+    access_key: $CLIPROXY_LOCAL_API_KEY
+
+routing_preferences:
+  - name: deep-technical-reasoning
+    description: Diagnosis-only reasoning with no code or file writing, modification, refactoring, review, or testing; includes root-cause, deadlocks and concurrency, architecture, security, and incident analysis; excludes trivial formatting, renaming, factual lookup, and simple summary.
+    models:
+      - anthropic/gpt-5.6-sol
+
+  - name: software-implementation
+    description: The requested deliverable includes nontrivial writing, modifying, refactoring, reviewing, or testing of code or files; excludes diagnosis-only reasoning and trivial formatting or renaming.
+    models:
+      - anthropic/gpt-5.6-terra
+
+  - name: quick-developer-utility
+    description: Only trivial formatting or renaming, short factual lookup, or simple summary; excludes debugging, root-cause or incident analysis, architecture, security, code review, testing, and code implementation.
+    models:
+      - anthropic/gpt-5.6-luna
+
+model_aliases:
+  claude-fable-5:
+    target: anthropic/gpt-5.6-sol
+  claude-opus-4-8:
+    target: anthropic/gpt-5.6-terra
+  claude-sonnet-5:
+    target: anthropic/gpt-5.6-luna
+  claude-haiku-4-5:
+    target: anthropic/gpt-5.6-luna

--- a/demos/llm_routing/claude_code_cliproxy/test.sh
+++ b/demos/llm_routing/claude_code_cliproxy/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# These tests use mocks and never start CLIProxyAPI or Plano.
+for test_file in "$SCRIPT_DIR"/tests/test_*.sh; do
+  bash "$test_file"
+done

--- a/demos/llm_routing/claude_code_cliproxy/tests/test_configs.sh
+++ b/demos/llm_routing/claude_code_cliproxy/tests/test_configs.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DEMO_DIR=$(cd "$TEST_DIR/.." && pwd)
+VALIDATOR="$DEMO_DIR/validate_configs.rb"
+PLANO_CONFIG="$DEMO_DIR/config.yaml"
+CLIPROXY_CONFIG="$DEMO_DIR/cliproxyapi.conf.example"
+README="$DEMO_DIR/README.md"
+
+fail() {
+  printf 'test_configs: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local expected=$1
+  shift
+  local output
+
+  if output=$("$@" 2>&1); then
+    fail "expected command to fail: $*"
+  fi
+  [[ $output == *"$expected"* ]] ||
+    fail "expected failure containing '$expected', got: $output"
+}
+
+for path in "$VALIDATOR" "$PLANO_CONFIG" "$CLIPROXY_CONFIG" "$README"; do
+  [[ -f $path ]] || fail "missing required file: $path"
+done
+
+ruby "$VALIDATOR" "$PLANO_CONFIG" "$CLIPROXY_CONFIG"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+ruby -ryaml -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), aliases: true)
+  config.fetch("model_providers").first["model"] += "[1m]"
+  File.write(ARGV.fetch(1), Psych.dump(config))
+' "$PLANO_CONFIG" "$tmp_dir/plano-suffixed.yaml"
+expect_failure 'must not contain [1m]' \
+  ruby "$VALIDATOR" "$tmp_dir/plano-suffixed.yaml" "$CLIPROXY_CONFIG"
+
+ruby -ryaml -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), aliases: true)
+  config["listeners"].first["address"] = "0.0.0.0"
+  File.write(ARGV.fetch(1), Psych.dump(config))
+' "$PLANO_CONFIG" "$tmp_dir/plano-public.yaml"
+expect_failure 'listener address must be 127.0.0.1' \
+  ruby "$VALIDATOR" "$tmp_dir/plano-public.yaml" "$CLIPROXY_CONFIG"
+
+ruby -ryaml -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), aliases: true)
+  config["remote-management"]["secret-key"] = "enabled-by-test"
+  File.write(ARGV.fetch(1), Psych.dump(config))
+' "$CLIPROXY_CONFIG" "$tmp_dir/cliproxy-management.yaml"
+expect_failure 'management API must be disabled' \
+  ruby "$VALIDATOR" "$PLANO_CONFIG" "$tmp_dir/cliproxy-management.yaml"
+
+ruby -ryaml -e '
+  config = Psych.safe_load_file(ARGV.fetch(0), aliases: true)
+  config["host"] = ""
+  File.write(ARGV.fetch(1), Psych.dump(config))
+' "$CLIPROXY_CONFIG" "$tmp_dir/cliproxy-public.yaml"
+expect_failure 'CLIProxyAPI host must be 127.0.0.1' \
+  ruby "$VALIDATOR" "$PLANO_CONFIG" "$tmp_dir/cliproxy-public.yaml"
+
+required_readme_text=(
+  'Plano 0.4.27'
+  'CLIProxyAPI 7.2.70'
+  '7.2.75'
+  'https://github.com/router-for-me/CLIProxyAPI'
+  'https://help.router-for.me/'
+  'gpt-5.6-sol'
+  'gpt-5.6-terra'
+  'gpt-5.6-luna'
+  '[1m]'
+  'Docker'
+  'rollback'
+)
+for text in "${required_readme_text[@]}"; do
+  grep -Fiq "$text" "$README" || fail "README missing required text: $text"
+done
+
+in_code_block=false
+while IFS= read -r line; do
+  if [[ $line == \`\`\`* ]]; then
+    if [[ $in_code_block == true ]]; then
+      in_code_block=false
+    else
+      in_code_block=true
+    fi
+    continue
+  fi
+  if [[ $in_code_block == true && $line == *"curl "* ]]; then
+    curl_args=${line#*curl }
+    [[ $curl_args == "-q --noproxy '*'"* ]] ||
+      fail "README curl must start with -q --noproxy '*': $line"
+  fi
+done <"$README"
+
+health_write_out_count=$(grep -Fc -- "--write-out '%{http_code}'" "$README" || true)
+((health_write_out_count == 2)) ||
+  fail "README must contain two exact-status Plano health examples, found $health_write_out_count"
+health_200_count=$(grep -Fc "[[ \$plano_status == 200 ]]" "$README" || true)
+((health_200_count == 2)) ||
+  fail "README must require HTTP 200 in both Plano health examples, found $health_200_count"
+
+mac_user_path='/''Users/'
+linux_user_path='/''home/'
+internal_alias='c''cx'
+internal_name='Pre''stance'
+prohibited_pattern="(${mac_user_path}|${linux_user_path}[^<[:space:]]+|${internal_alias}|${internal_name}|sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9]{12,})"
+scan_paths=(
+  "$README"
+  "$PLANO_CONFIG"
+  "$CLIPROXY_CONFIG"
+  "$DEMO_DIR/claude-plano"
+  "$VALIDATOR"
+  "$DEMO_DIR/test.sh"
+  "$DEMO_DIR/tests/test_launcher.sh"
+  "$DEMO_DIR/tests/test_configs.sh"
+)
+if grep -Eiq "$prohibited_pattern" "${scan_paths[@]}"; then
+  fail 'demo contains a prohibited local path, internal reference, or credential-like value'
+fi
+
+printf 'test_configs: PASS\n'

--- a/demos/llm_routing/claude_code_cliproxy/tests/test_launcher.sh
+++ b/demos/llm_routing/claude_code_cliproxy/tests/test_launcher.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DEMO_DIR=$(cd "$TEST_DIR/.." && pwd)
+LAUNCHER="$DEMO_DIR/claude-plano"
+SYSTEM_RUBY=$(command -v ruby || true)
+FIXTURE_ROOT=
+trap '[[ -z $FIXTURE_ROOT ]] || rm -rf "$FIXTURE_ROOT"' EXIT
+
+fail() {
+  printf 'test_launcher: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack=$1
+  local needle=$2
+  local label=$3
+  [[ $haystack == *"$needle"* ]] ||
+    fail "$label: expected output containing '$needle', got: $haystack"
+}
+
+assert_not_contains() {
+  local haystack=$1
+  local needle=$2
+  local label=$3
+  [[ $haystack != *"$needle"* ]] ||
+    fail "$label: unexpected output containing '$needle'"
+}
+
+write_mocks() {
+  local bin_dir=$1
+
+  cat >"$bin_dir/claude" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'ANTHROPIC_BASE_URL=%s\n' "${ANTHROPIC_BASE_URL:-}"
+  printf 'ANTHROPIC_AUTH_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-}"
+  printf 'ANTHROPIC_API_KEY=%s\n' "${ANTHROPIC_API_KEY:-<unset>}"
+  printf 'CLIPROXY_LOCAL_API_KEY=%s\n' "${CLIPROXY_LOCAL_API_KEY:-<unset>}"
+  printf 'ANTHROPIC_MODEL=%s\n' "${ANTHROPIC_MODEL:-}"
+  printf 'ANTHROPIC_DEFAULT_FABLE_MODEL=%s\n' "${ANTHROPIC_DEFAULT_FABLE_MODEL:-}"
+  printf 'ANTHROPIC_DEFAULT_OPUS_MODEL=%s\n' "${ANTHROPIC_DEFAULT_OPUS_MODEL:-}"
+  printf 'ANTHROPIC_DEFAULT_SONNET_MODEL=%s\n' "${ANTHROPIC_DEFAULT_SONNET_MODEL:-}"
+  printf 'ANTHROPIC_DEFAULT_HAIKU_MODEL=%s\n' "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}"
+  printf 'ARGC=%s\n' "$#"
+  index=0
+  for arg in "$@"; do
+    printf 'ARG[%s]=<%s>\n' "$index" "$arg"
+    index=$((index + 1))
+  done
+} >"$MOCK_CALLS/claude.log"
+env | LC_ALL=C sort >"$MOCK_CALLS/claude.env"
+MOCK
+
+  cat >"$bin_dir/curl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ ${1:-} == -q ]] || exit 65
+[[ -z ${CLIPROXY_LOCAL_API_KEY:-} ]] || exit 66
+proxy_bypass=false
+previous=
+for arg in "$@"; do
+  [[ $previous != --noproxy || $arg != '*' ]] || proxy_bypass=true
+  previous=$arg
+done
+[[ $proxy_bypass == true ]] || exit 67
+url=${!#}
+printf '%s\n' "$*" >>"$MOCK_CALLS/curl.log"
+case $url in
+  */v1/models)
+    IFS= read -r auth_header
+    [[ $auth_header == 'Authorization: Bearer '* ]] || exit 68
+    if [[ ${MOCK_INVALID_KEY:-0} == 1 ]]; then
+      printf 'curl: (22) The requested URL returned error: 401\n' >&2
+      exit 22
+    fi
+    if [[ -n ${MOCK_MODELS_JSON:-} ]]; then
+      printf '%s\n' "$MOCK_MODELS_JSON"
+    else
+      printf '%s\n' '{"data":[{"id":"gpt-5.6-sol"},{"id":"gpt-5.6-terra"},{"id":"gpt-5.6-luna"}]}'
+    fi
+    ;;
+  */healthz)
+    printf '%s' "${MOCK_PLANO_STATUS:-200}"
+    ;;
+  *)
+    printf 'unexpected mock curl URL: %s\n' "$url" >&2
+    exit 64
+    ;;
+esac
+MOCK
+
+  cat >"$bin_dir/lsof" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z ${CLIPROXY_LOCAL_API_KEY:-} ]] || exit 66
+case ${MOCK_LISTENER:-loopback} in
+  loopback) printf 'p4242\nn127.0.0.1:8317\n' ;;
+  ipv6) printf 'p4242\nn[::1]:8317\n' ;;
+  wildcard) printf 'p4242\nn*:8317\n' ;;
+  missing) exit 1 ;;
+  *) exit 64 ;;
+esac
+MOCK
+
+  chmod +x "$bin_dir/claude" "$bin_dir/curl" "$bin_dir/lsof"
+}
+
+new_fixture() {
+  FIXTURE_ROOT=$(mktemp -d)
+  mkdir -p "$FIXTURE_ROOT/bin" "$FIXTURE_ROOT/calls" "$FIXTURE_ROOT/home"
+  MOCK_CALLS="$FIXTURE_ROOT/calls"
+  export MOCK_CALLS
+  write_mocks "$FIXTURE_ROOT/bin"
+
+  CLIPROXY_CONFIG="$FIXTURE_ROOT/cliproxy.yaml"
+  cat >"$CLIPROXY_CONFIG" <<'YAML'
+host: 127.0.0.1
+port: 8317
+api-keys:
+  - config-canary-key
+YAML
+
+  export HOME="$FIXTURE_ROOT/home"
+  export PATH="$FIXTURE_ROOT/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  export CLIPROXY_CONFIG
+  export CLAUDE_BIN="$FIXTURE_ROOT/bin/claude"
+  export CURL_BIN="$FIXTURE_ROOT/bin/curl"
+  export LSOF_BIN="$FIXTURE_ROOT/bin/lsof"
+  export RUBY_BIN="$SYSTEM_RUBY"
+  export CLIPROXY_URL=http://127.0.0.1:8317
+  export PLANO_URL=http://127.0.0.1:12000
+  unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL
+  unset CLIPROXY_LOCAL_API_KEY MOCK_INVALID_KEY MOCK_MODELS_JSON
+  unset MOCK_LISTENER MOCK_PLANO_STATUS
+  STDOUT_FILE="$FIXTURE_ROOT/stdout"
+  STDERR_FILE="$FIXTURE_ROOT/stderr"
+}
+
+cleanup_fixture() {
+  rm -rf "$FIXTURE_ROOT"
+}
+
+run_launcher() {
+  "$LAUNCHER" "$@" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+}
+
+run_launcher_with_allexport() {
+  bash -a "$LAUNCHER" "$@" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+}
+
+expect_failure() {
+  local expected=$1
+  shift
+  if run_launcher "$@"; then
+    fail "expected launcher failure containing: $expected"
+  fi
+  assert_contains "$(<"$STDERR_FILE")" "$expected" "failure message"
+  [[ ! -f $MOCK_CALLS/claude.log ]] || fail 'Claude ran after failed preflight'
+}
+
+[[ -x $LAUNCHER ]] || fail "missing executable launcher: $LAUNCHER"
+[[ -n $SYSTEM_RUBY ]] || fail 'ruby is required to run launcher tests'
+if grep -Fq -- '--dangerously-skip-permissions' "$LAUNCHER"; then
+  fail 'launcher must not disable Claude Code permission checks'
+fi
+if grep -Eq 'planoai (up|down)|PLANOAI_BIN|PLANO_STATE|PLANO_LOCK|kill |owner\.pid|attestation' "$LAUNCHER"; then
+  fail 'launcher must not supervise services, PIDs, locks, or state'
+fi
+launcher_lines=$(wc -l <"$LAUNCHER" | tr -d ' ')
+((launcher_lines < 140)) || fail "launcher must stay under 140 lines, got $launcher_lines"
+
+# Happy path: key comes from explicit config and all required models are present.
+new_fixture
+run_launcher --print ready
+claude_log=$(<"$MOCK_CALLS/claude.log")
+assert_contains "$claude_log" 'ANTHROPIC_BASE_URL=http://127.0.0.1:12000' 'Plano base URL'
+assert_contains "$claude_log" 'ANTHROPIC_AUTH_TOKEN=local-plano-proxy' 'local gateway token'
+assert_contains "$claude_log" 'ANTHROPIC_MODEL=opus' 'default model alias'
+assert_contains "$claude_log" 'ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5' 'Fable alias target'
+assert_contains "$claude_log" 'ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8' 'Opus alias target'
+assert_contains "$claude_log" 'ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-5' 'Sonnet alias target'
+assert_contains "$claude_log" 'ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5' 'Haiku alias target'
+claude_env=$(<"$MOCK_CALLS/claude.env")
+assert_not_contains "$claude_env" 'config-canary-key' 'config-file CLIProxy key absent from Claude environment'
+cleanup_fixture
+
+# Invalid local key: authenticated model discovery must fail closed.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=wrong-key
+export MOCK_INVALID_KEY=1
+expect_failure 'CLIProxyAPI authentication or model discovery failed' --print blocked
+cleanup_fixture
+
+# Missing required model: all three routing tiers must be advertised.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+export MOCK_MODELS_JSON='{"data":[{"id":"gpt-5.6-sol"},{"id":"gpt-5.6-terra"}]}'
+expect_failure 'missing required model: gpt-5.6-luna' --print blocked
+cleanup_fixture
+
+# Wildcard listener: a reachable service is not enough; it must be loopback-only.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+export MOCK_LISTENER=wildcard
+expect_failure 'CLIProxyAPI listener must be loopback-only' --print blocked
+cleanup_fixture
+
+# Plano unavailable: launcher never starts services and fails before Claude.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+export MOCK_PLANO_STATUS=503
+expect_failure 'Plano health check failed with HTTP 503' --print blocked
+cleanup_fixture
+
+# The CLIProxy secret must not survive anywhere in Claude's environment.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=secret-canary
+export cliproxy_key=secret-canary
+run_launcher --print scrubbed
+claude_log=$(<"$MOCK_CALLS/claude.log")
+claude_env=$(<"$MOCK_CALLS/claude.env")
+assert_contains "$claude_log" 'CLIPROXY_LOCAL_API_KEY=<unset>' 'CLIProxy key scrubbed'
+assert_not_contains "$claude_env" 'secret-canary' 'pre-exported CLIProxy key absent from Claude environment'
+cleanup_fixture
+
+# Allexport must not turn the internal key copy into a Claude environment variable.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=allexport-secret-canary
+run_launcher_with_allexport --print scrubbed
+claude_env=$(<"$MOCK_CALLS/claude.env")
+assert_not_contains "$claude_env" 'allexport-secret-canary' 'allexport CLIProxy key absent from Claude environment'
+cleanup_fixture
+
+# IPv6 loopback literals are valid for the CLIProxyAPI URL.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+export CLIPROXY_URL='http://[::1]:8317'
+export MOCK_LISTENER=ipv6
+run_launcher --print ipv6-cliproxy
+cleanup_fixture
+
+# IPv6 loopback literals are valid for the Plano URL.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+export PLANO_URL='http://[::1]:12000'
+run_launcher --print ipv6-plano
+cleanup_fixture
+
+# Exact argument forwarding preserves spaces, shell metacharacters, and empties.
+new_fixture
+export CLIPROXY_LOCAL_API_KEY=environment-key
+run_launcher --print 'argument with spaces' 'semi;colon' ''
+claude_log=$(<"$MOCK_CALLS/claude.log")
+assert_contains "$claude_log" 'ARGC=4' 'argument count'
+assert_contains "$claude_log" 'ARG[0]=<--print>' 'first argument'
+assert_contains "$claude_log" 'ARG[1]=<argument with spaces>' 'spaced argument'
+assert_contains "$claude_log" 'ARG[2]=<semi;colon>' 'metacharacter argument'
+assert_contains "$claude_log" 'ARG[3]=<>' 'empty argument'
+cleanup_fixture
+
+printf 'test_launcher: PASS\n'

--- a/demos/llm_routing/claude_code_cliproxy/validate_configs.rb
+++ b/demos/llm_routing/claude_code_cliproxy/validate_configs.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "psych"
+require "set"
+
+EXPECTED_MODELS = Set[
+  "anthropic/gpt-5.6-sol",
+  "anthropic/gpt-5.6-terra",
+  "anthropic/gpt-5.6-luna"
+].freeze
+
+EXPECTED_ROUTES = {
+  "deep-technical-reasoning" => {
+    "description" => "Diagnosis-only reasoning with no code or file writing, modification, refactoring, review, or testing; includes root-cause, deadlocks and concurrency, architecture, security, and incident analysis; excludes trivial formatting, renaming, factual lookup, and simple summary.",
+    "model" => "anthropic/gpt-5.6-sol"
+  },
+  "software-implementation" => {
+    "description" => "The requested deliverable includes nontrivial writing, modifying, refactoring, reviewing, or testing of code or files; excludes diagnosis-only reasoning and trivial formatting or renaming.",
+    "model" => "anthropic/gpt-5.6-terra"
+  },
+  "quick-developer-utility" => {
+    "description" => "Only trivial formatting or renaming, short factual lookup, or simple summary; excludes debugging, root-cause or incident analysis, architecture, security, code review, testing, and code implementation.",
+    "model" => "anthropic/gpt-5.6-luna"
+  }
+}.freeze
+
+EXPECTED_ALIASES = {
+  "claude-fable-5" => "anthropic/gpt-5.6-sol",
+  "claude-opus-4-8" => "anthropic/gpt-5.6-terra",
+  "claude-sonnet-5" => "anthropic/gpt-5.6-luna",
+  "claude-haiku-4-5" => "anthropic/gpt-5.6-luna"
+}.freeze
+
+
+def fail_validation(message)
+  warn "validate_configs: #{message}"
+  exit 1
+end
+
+
+def load_yaml(path, label)
+  parsed = Psych.safe_load_file(path, permitted_classes: [], permitted_symbols: [], aliases: false)
+  fail_validation("#{label} root must be a mapping") unless parsed.is_a?(Hash)
+
+  parsed
+rescue Errno::ENOENT
+  fail_validation("#{label} file not found")
+rescue Psych::Exception
+  fail_validation("#{label} must be valid safe YAML without aliases or object tags")
+end
+
+
+def validate_plano(config)
+  fail_validation("Plano version must be v0.4.0") unless config["version"] == "v0.4.0"
+
+  listeners = config["listeners"]
+  fail_validation("Plano must define exactly one listener") unless listeners.is_a?(Array) && listeners.length == 1
+
+  listener = listeners.first
+  fail_validation("listeners[0] must be a mapping") unless listener.is_a?(Hash)
+  fail_validation("listener type must be model") unless listener["type"] == "model"
+  fail_validation("listener address must be 127.0.0.1") unless listener["address"] == "127.0.0.1"
+  fail_validation("listener port must be 12000") unless listener["port"] == 12_000
+
+  providers = config["model_providers"]
+  fail_validation("Plano must define exactly three model providers") unless providers.is_a?(Array) && providers.length == 3
+  fail_validation("model_providers entries must be mappings") unless providers.all? { |provider| provider.is_a?(Hash) }
+
+  provider_models = providers.map { |provider| provider["model"] }
+  if provider_models.any? { |model| model.to_s.include?("[1m]") }
+    fail_validation("Plano model IDs must not contain [1m]")
+  end
+  fail_validation("Plano model provider IDs do not match the required tiers") unless provider_models.to_set == EXPECTED_MODELS
+
+  providers.each_with_index do |provider, index|
+    fail_validation("model_providers[#{index}].base_url must target local CLIProxyAPI") unless provider["base_url"] == "http://127.0.0.1:8317"
+    fail_validation("model_providers[#{index}].access_key must reference CLIPROXY_LOCAL_API_KEY") unless provider["access_key"] == "$CLIPROXY_LOCAL_API_KEY"
+  end
+
+  defaults = providers.select { |provider| provider["default"] == true }
+  unless defaults.length == 1 && defaults.first["model"] == "anthropic/gpt-5.6-terra"
+    fail_validation("Terra must be the only default model provider")
+  end
+
+  routes = config["routing_preferences"]
+  fail_validation("Plano must define exactly three routing preferences") unless routes.is_a?(Array) && routes.length == 3
+  fail_validation("routing_preferences entries must be mappings") unless routes.all? { |route| route.is_a?(Hash) }
+
+  route_names = routes.map { |route| route["name"] }
+  fail_validation("routing preference names do not match the required routes") unless route_names.to_set == EXPECTED_ROUTES.keys.to_set
+
+  routes.each do |route|
+    expected = EXPECTED_ROUTES.fetch(route["name"])
+    fail_validation("routing preference description does not match its mutually exclusive contract") unless route["description"] == expected["description"]
+    fail_validation("routing preference must select exactly its assigned tier") unless route["models"] == [expected["model"]]
+  end
+
+  aliases = config["model_aliases"]
+  fail_validation("model_aliases must be a mapping") unless aliases.is_a?(Hash)
+  actual_aliases = aliases.transform_values { |value| value.is_a?(Hash) ? value["target"] : nil }
+  if actual_aliases.values.any? { |target| target.to_s.include?("[1m]") }
+    fail_validation("Plano alias targets must not contain [1m]")
+  end
+  fail_validation("Claude family aliases do not match the required tiers") unless actual_aliases == EXPECTED_ALIASES
+end
+
+
+def validate_cliproxy(config)
+  fail_validation("CLIProxyAPI host must be 127.0.0.1") unless config["host"] == "127.0.0.1"
+  fail_validation("CLIProxyAPI port must be 8317") unless config["port"] == 8317
+
+  management = config["remote-management"]
+  fail_validation("remote-management must be a mapping") unless management.is_a?(Hash)
+  unless management["allow-remote"] == false && management["secret-key"].to_s.empty?
+    fail_validation("management API must be disabled")
+  end
+  fail_validation("management control panel must be disabled") unless management["disable-control-panel"] == true
+
+  keys = config["api-keys"]
+  unless keys == ["replace-with-a-random-local-key"]
+    fail_validation("api-keys must contain only the documented placeholder")
+  end
+end
+
+if ARGV.length != 2
+  fail_validation("usage: validate_configs.rb PLANO_CONFIG CLIPROXY_CONFIG")
+end
+
+validate_plano(load_yaml(ARGV.fetch(0), "Plano config"))
+validate_cliproxy(load_yaml(ARGV.fetch(1), "CLIProxyAPI config"))


### PR DESCRIPTION
## Summary

Adds a reproducible demo for routing Claude Code across Codex subscription models through Plano while delegating protocol translation and OAuth handling to a local [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) upstream.

The data path is:

```text
Claude Code -> Plano preference routing -> CLIProxyAPI /v1/messages -> Codex OAuth
```

This keeps Plano focused on preference routing and model aliases, while CLIProxyAPI owns the Anthropic-to-Codex compatibility layer.

## Included

- Plano v0.4 config with three Anthropic-compatible upstream models:
  - `gpt-5.6-sol` for diagnosis-only deep reasoning
  - `gpt-5.6-terra` for implementation work
  - `gpt-5.6-luna` for quick developer utilities
- Claude family fallback aliases: Fable→Sol, Opus→Terra, Sonnet/Haiku→Luna
- Loopback-only CLIProxyAPI config example with management disabled
- Small preflight-only `claude-plano` launcher that:
  - validates loopback binding
  - authenticates `/v1/models`
  - verifies all required models
  - checks Plano health
  - removes the proxy key before executing Claude Code
- Full setup guide for Homebrew and non-Homebrew installs, Codex OAuth login, local/native startup, Docker production isolation, troubleshooting, rollback, and context-window model naming
- Mock-based launcher tests and structural config/README policy validation

## Important boundaries

- CLIProxyAPI is an independent MIT-licensed project, not part of Plano, Anthropic, or OpenAI.
- Public wire model IDs remain unsuffixed. Claude Code client annotations such as `[1m]` are optional client-side hints and are not CLIProxyAPI model IDs.
- Top-level routing preferences override Claude family alias targets when a route matches; aliases remain initial/fallback targets.
- Native Plano internal listeners are explicitly pinned to loopback in the documented development command. Docker isolation is recommended for production.
- The public launcher intentionally does not use `--dangerously-skip-permissions`.

## Test plan

```bash
cd demos/llm_routing/claude_code_cliproxy
./test.sh
shfmt -i 2 -ci -d claude-plano test.sh tests/*.sh
shellcheck claude-plano test.sh tests/*.sh
ruby -c validate_configs.rb
ruby validate_configs.rb config.yaml cliproxyapi.conf.example
```

All checks pass locally. Tests use mocks and do not require credentials, OAuth login, or model inference.

## Validation performed during development

The integration was also exercised end-to-end outside the committed test suite with Claude Code single-turn, multi-turn, streaming/non-streaming, file tools, Explore subagents, all four Claude alias families, hosted Sol/Terra/Luna routing, and direct-proxy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)