### PR TITLE
fix(deps): patch serde_with, tokio-postgres, turbo, undici, next for disclosed CVEs

### DIFF
--- a/crates/brightstaff/Cargo.toml
+++ b/crates/brightstaff/Cargo.toml
@@ -47,14 +47,14 @@ redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "tls-
 reqwest = { version = "0.12.15", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-serde_with = "3.13.0"
+serde_with = "3.21.0"
 strsim = "0.11"
 serde_yaml = "0.9.34"
 thiserror = "2.0.12"
 tikv-jemallocator = { version = "0.6", optional = true }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
 tokio = { version = "1.44.2", features = ["full"] }
-tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
+tokio-postgres = { version = "0.7.18", features = ["with-serde_json-1"] }
 tokio-stream = "0.1"
 time = { version = "0.3", features = ["formatting", "macros"] }
 tracing = "0.1"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4.3"
 urlencoding = "2.1.3"
 url = "2.5.4"
 hermesllm = { version = "0.1.0", path = "../hermesllm" }
-serde_with = "3.13.0"
+serde_with = "3.21.0"
 hyper = "1.0"
 bytes = "1.0"
 http-body-util = "0.1"

--- a/crates/hermesllm/Cargo.toml
+++ b/crates/hermesllm/Cargo.toml
@@ -12,7 +12,7 @@ required-features = ["model-fetch"]
 serde = {version = "1.0.219", features = ["derive"]}
 serde_json = "1.0.140"
 serde_yaml = "0.9.34-deprecated"
-serde_with = {version = "3.12.0", features = ["base64"]}
+serde_with = {version = "3.21.0", features = ["base64"]}
 thiserror = "2.0.12"
 aws-smithy-eventstream = "0.60"
 bytes = "1.10"

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "turbo": "^2.6.3"
+    "turbo": "^2.9.14"
   },
   "engines": {
     "node": ">=18.0.0"
   },
   "packageManager": "npm@10.0.0",
   "overrides": {
-    "undici": "^7.0.0"
+    "undici": "^7.28.0"
   },
   "dependencies": {
-    "next": "^16.1.6",
+    "next": "^16.2.11",
     "react": "^19.2.3",
     "resend": "^6.6.0"
   }


### PR DESCRIPTION
Automated dependency bump to address several disclosed security advisories detected by [osv-scanner](https://google.github.io/osv-scanner/).

## Rust (crates/)

After running `cargo update` to regenerate `crates/Cargo.lock`, the following advisories will be resolved:

### serde_with 3.12/3.13 → 3.21.0 (all crates)
- **GHSA-7gcf-g7xr-8hxj** — fixed in 3.21.0
- Files: `crates/brightstaff/Cargo.toml`, `crates/common/Cargo.toml`, `crates/hermesllm/Cargo.toml`

### tokio-postgres 0.7.x → 0.7.18 (brightstaff)
- **RUSTSEC-2026-0178** — denial-of-service (CVSS medium, network-reachable)
- **RUSTSEC-2026-0179** — denial-of-service (CVSS high, network-reachable)
- **RUSTSEC-2026-0180** — denial-of-service (CVSS low)
- File: `crates/brightstaff/Cargo.toml`

### Additional transitive advisories (manual `cargo update` can resolve)
- **openssl 0.10.77 → 0.10.80**: 7 CVEs (GHSA-8c75, GHSA-ghm9, GHSA-hppc, GHSA-phqj, GHSA-pqf5, GHSA-xmgf, GHSA-xp3w) — transitive via reqwest/native-tls
- **quinn-proto 0.11.14 → 0.11.15**: RUSTSEC-2026-0185 / CVE-2026-25800 (DoS, CVSS 7.5 HIGH) — transitive
- **opentelemetry_sdk 0.31 → 0.32.1**: GHSA-w9wp-h8wv-79jx — major bump, may require API changes
- **lru 0.12 → 0.16.3**: RUSTSEC-2026-0002 (unsound memory corruption) — major bump, may require API changes
- **rustls-webpki 0.101.7**: 3 advisories — transitive via redis

To regenerate the Rust lockfile:
```
cd crates && cargo update -p serde_with --precise 3.21.0
cd crates && cargo update -p tokio-postgres --precise 0.7.18
cd crates && cargo update -p openssl --precise 0.10.80
cd crates && cargo update -p quinn-proto --precise 0.11.15
```

## npm (package.json)

After running `npm install` to regenerate `package-lock.json`:

### turbo 2.9.3 → 2.9.14
- **GHSA-3qcw-2rhx-2726** (CVE-2026-45772)
- **GHSA-hcf7-66rw-9f5r** (CVE-2026-45773)

### undici 7.24.7 → 7.28.0 (overrides)
- **GHSA-hm92-r4w5-c3mj** (CVE-2026-6734)
- **GHSA-pr7r-676h-xcf6** (CVE-2026-9678)
- **GHSA-vmh5-mc38-953g** (CVE-2026-9697)
- And 4 additional undici CVEs fixed in 7.28.0

### next 16.2.2 → 16.2.11
- **GHSA-6gpp-xcg3-4w24** (CVE-2026-64642) — fixed in 16.2.11

### Additional transitive npm advisories (npm overrides/npm audit fix may help)
- dompurify 3.3.3 → 3.4.12: 12 XSS-related advisories
- vite 7.3.1: 5 advisories (major bump to 8.x needed)
- tar 7.5.13 → 7.5.19: 5 CVEs
- ws 8.20.0 → 8.20.1: 2 CVEs

---

Detected by [osv-scanner](https://google.github.io/osv-scanner/) 2.4.0.
Lockfiles need regeneration after merging (`cargo update` in `crates/` and `npm install` in the monorepo root).
Filed by [Aeon](https://github.com/aeonframework/aeon).