### PR TITLE
feat: add Eden AI as a model provider

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -33,6 +33,7 @@ SUPPORTED_PROVIDERS_WITHOUT_BASE_URL = [
     "digitalocean",
     "vercel",
     "openrouter",
+    "edenai",
 ]
 
 CHATGPT_API_BASE = "https://chatgpt.com/backend-api/codex"

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -96,6 +96,15 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         base_url="https://openrouter.ai/api/v1",
         model_pattern="openrouter/*",
     ),
+    # Eden AI is an EU-based, OpenAI-compatible gateway routing to many upstream
+    # providers behind one key — same treatment as OpenRouter, no
+    # provider_interface override needed.
+    ProviderDefault(
+        name="edenai",
+        env_var="EDENAI_API_KEY",
+        base_url="https://api.edenai.run/v3",
+        model_pattern="edenai/*",
+    ),
 ]
 
 

--- a/cli/test/test_config_generator.py
+++ b/cli/test/test_config_generator.py
@@ -298,6 +298,24 @@ model_providers:
 """,
     },
     {
+        "id": "edenai_is_supported_provider",
+        "expected_error": None,
+        "plano_config": """
+version: v0.4.0
+
+listeners:
+  - name: llm
+    type: model
+    port: 12000
+
+model_providers:
+  - model: edenai/*
+    base_url: https://api.edenai.run/v3
+    passthrough_auth: true
+
+""",
+    },
+    {
         "id": "duplicate_routeing_preference_name",
         "expected_error": "Duplicate routing preference name",
         "plano_config": """

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -30,6 +30,7 @@ def test_zero_env_vars_produces_pure_passthrough():
     assert "digitalocean" in names
     assert "vercel" in names
     assert "openrouter" in names
+    assert "edenai" in names
     assert "openai" in names
     assert "anthropic" in names
 
@@ -109,3 +110,18 @@ def test_openrouter_env_key_promotes_to_env_keyed():
     by_name = {p["name"]: p for p in cfg["model_providers"]}
     assert by_name["openrouter"].get("access_key") == "$OPENROUTER_API_KEY"
     assert by_name["openrouter"].get("passthrough_auth") is None
+
+
+def test_provider_defaults_edenai_is_configured():
+    by_name = {p.name: p for p in PROVIDER_DEFAULTS}
+    assert "edenai" in by_name
+    assert by_name["edenai"].env_var == "EDENAI_API_KEY"
+    assert by_name["edenai"].base_url == "https://api.edenai.run/v3"
+    assert by_name["edenai"].model_pattern == "edenai/*"
+
+
+def test_edenai_env_key_promotes_to_env_keyed():
+    cfg = synthesize_default_config(env={"EDENAI_API_KEY": "eden-1"})
+    by_name = {p["name"]: p for p in cfg["model_providers"]}
+    assert by_name["edenai"].get("access_key") == "$EDENAI_API_KEY"
+    assert by_name["edenai"].get("passthrough_auth") is None

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -201,6 +201,7 @@ properties:
             - digitalocean
             - vercel
             - openrouter
+            - edenai
             - moonshotai
         headers:
           type: object
@@ -260,6 +261,7 @@ properties:
             - digitalocean
             - vercel
             - openrouter
+            - edenai
             - moonshotai
         headers:
           type: object

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -53,6 +53,7 @@ pub enum ProviderId {
     AstraflowCN,
     Meta,
     Minimax,
+    EdenAI,
 }
 
 impl TryFrom<&str> for ProviderId {
@@ -90,6 +91,7 @@ impl TryFrom<&str> for ProviderId {
             "astraflow_cn" => Ok(ProviderId::AstraflowCN),
             "meta" => Ok(ProviderId::Meta),
             "minimax" => Ok(ProviderId::Minimax),
+            "edenai" => Ok(ProviderId::EdenAI),
             _ => Err(format!("Unknown provider: {}", value)),
         }
     }
@@ -151,7 +153,10 @@ fn model_family(model_name: &str) -> ModelFamily {
 /// Whether a gateway accepts Anthropic-style `cache_control` on OpenAI content parts
 /// over its chat-completions endpoint.
 fn accepts_openai_content_part_cache_control(provider: ProviderId) -> bool {
-    matches!(provider, ProviderId::DigitalOcean | ProviderId::OpenRouter)
+    matches!(
+        provider,
+        ProviderId::DigitalOcean | ProviderId::OpenRouter | ProviderId::EdenAI
+    )
 }
 
 /// Whether a gateway/model relies on automatic prefix caching (no markers required)
@@ -169,6 +174,7 @@ fn is_automatic_cache_provider(provider: ProviderId) -> bool {
             | ProviderId::XAI
             | ProviderId::DigitalOcean
             | ProviderId::OpenRouter
+            | ProviderId::EdenAI
     )
 }
 
@@ -266,6 +272,7 @@ pub fn provider_cache_capability(provider: ProviderId) -> ProviderCacheCapabilit
         ProviderId::Anthropic
         | ProviderId::DigitalOcean
         | ProviderId::OpenRouter
+        | ProviderId::EdenAI
         | ProviderId::Vercel => ProviderCacheCapability::default(),
         // OpenAI-family automatic prefix caching also lives on the order of minutes;
         // the conservative default holds.
@@ -376,7 +383,8 @@ impl ProviderId {
                 | ProviderId::Astraflow
                 | ProviderId::AstraflowCN
                 | ProviderId::Meta
-                | ProviderId::Minimax,
+                | ProviderId::Minimax
+                | ProviderId::EdenAI,
                 SupportedAPIsFromClient::AnthropicMessagesAPI(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -402,7 +410,8 @@ impl ProviderId {
                 | ProviderId::Astraflow
                 | ProviderId::AstraflowCN
                 | ProviderId::Meta
-                | ProviderId::Minimax,
+                | ProviderId::Minimax
+                | ProviderId::EdenAI,
                 SupportedAPIsFromClient::OpenAIChatCompletions(_),
             ) => SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
 
@@ -477,6 +486,7 @@ impl Display for ProviderId {
             ProviderId::AstraflowCN => write!(f, "astraflow_cn"),
             ProviderId::Meta => write!(f, "meta"),
             ProviderId::Minimax => write!(f, "minimax"),
+            ProviderId::EdenAI => write!(f, "edenai"),
         }
     }
 }
@@ -784,6 +794,62 @@ mod tests {
             matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
             "minimax should translate Anthropic client to OpenAIChatCompletions upstream"
         );
+    }
+
+    #[test]
+    fn test_edenai_parsing() {
+        assert_eq!(ProviderId::try_from("edenai"), Ok(ProviderId::EdenAI));
+        assert_eq!(ProviderId::EdenAI.to_string(), "edenai");
+        assert!(ProviderId::try_from("eden_ai").is_err());
+    }
+
+    #[test]
+    fn test_edenai_empty_models() {
+        // Eden AI is a broad multi-vendor gateway, same as OpenRouter/Vercel: no
+        // static model list to keep, models() correctly falls through to empty.
+        assert!(ProviderId::EdenAI.models().is_empty());
+    }
+
+    #[test]
+    fn test_edenai_compatible_api() {
+        use crate::clients::endpoints::{SupportedAPIsFromClient, SupportedUpstreamAPIs};
+
+        let openai_client =
+            SupportedAPIsFromClient::OpenAIChatCompletions(OpenAIApi::ChatCompletions);
+        let upstream = ProviderId::EdenAI.compatible_api_for_client(&openai_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "EdenAI should map OpenAI client to OpenAIChatCompletions upstream"
+        );
+
+        let anthropic_client =
+            SupportedAPIsFromClient::AnthropicMessagesAPI(AnthropicApi::Messages);
+        let upstream = ProviderId::EdenAI.compatible_api_for_client(&anthropic_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "EdenAI should translate Anthropic client to OpenAIChatCompletions upstream"
+        );
+
+        let responses_client = SupportedAPIsFromClient::OpenAIResponsesAPI(OpenAIApi::Responses);
+        let upstream = ProviderId::EdenAI.compatible_api_for_client(&responses_client, false);
+        assert!(
+            matches!(upstream, SupportedUpstreamAPIs::OpenAIChatCompletions(_)),
+            "EdenAI should translate Responses API client to OpenAIChatCompletions upstream"
+        );
+    }
+
+    #[test]
+    fn edenai_anthropic_uses_openai_content_part_markers() {
+        // Eden AI uses slash-form model ids after the gateway prefix, same as OpenRouter.
+        let strategy = cache_marker_strategy(
+            ProviderId::EdenAI,
+            "anthropic/claude-3.5-sonnet",
+            &chat_completions(),
+        );
+        assert!(matches!(
+            strategy,
+            CacheMarkerStrategy::OpenAiContentPartCacheControl { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds [Eden AI](https://www.edenai.co/) as a model provider. Eden AI is an EU-based, OpenAI-compatible gateway that routes to many upstream providers behind a single API key. Models are addressed as `<provider>/<model>`, e.g. `openai/gpt-4o-mini` or `anthropic/claude-haiku-4-5`.

Mirrors the existing OpenRouter treatment exactly, since both are broad OpenAI-compatible gateways with no static model list:

- `crates/hermesllm/src/providers/id.rs`: new `ProviderId::EdenAI` variant, parsing (`edenai`), Display, routed as `OpenAIChatCompletions` across all client API shapes (same as OpenRouter), same cache marker strategy (content-part `cache_control` for Anthropic-family models over chat completions)
- `cli/planoai/defaults.py`: zero-config default entry (`EDENAI_API_KEY`, `base_url: https://api.edenai.run/v3`)
- `cli/planoai/config_generator.py` and `config/plano_config_schema.yaml`: added `edenai` to the supported provider lists, same spot as `openrouter`

## Testing

- `cargo test -p hermesllm`: all tests pass, including new EdenAI-specific ones (parsing, compatible_api_for_client, cache marker strategy, empty models list)
- `cargo fmt --check` and `cargo clippy`: clean
- `uv run pytest` (cli): all tests pass, including new ones for `defaults.py` (provider default config, env-key promotion) and `config_generator.py` (schema validation)
- Tested live against the real Eden AI API (`https://api.edenai.run/v3/chat/completions`) across three underlying vendors, all HTTP 200:
  - `openai/gpt-4o-mini`
  - `mistral/mistral-small-latest`
  - `anthropic/claude-haiku-4-5`

fixes #997