### PR TITLE
Add Kimi K3 support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -379,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,9 +2411,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -2420,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3247,11 +3256,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3266,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3739,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -164,6 +164,66 @@ impl ChatCompletionsRequest {
         }
     }
 
+    /// Map an OpenAI-style `reasoning_effort` onto the values Kimi K3 accepts
+    /// (`low`, `high`, `max`). K3 cannot disable thinking, so the efforts below
+    /// `low` collapse onto it. Unrecognized values are dropped so that the
+    /// upstream default applies rather than the request being rejected.
+    fn normalize_kimi_k3_reasoning_effort(&mut self) {
+        let Some(effort) = self.reasoning_effort.as_deref() else {
+            return;
+        };
+        let mapped = match effort.to_ascii_lowercase().as_str() {
+            "none" | "minimal" | "low" => Some("low"),
+            "medium" | "high" => Some("high"),
+            "max" => Some("max"),
+            _ => None,
+        };
+        match mapped {
+            Some(mapped) if mapped == effort => {}
+            Some(mapped) => {
+                warn!(
+                    "kimi-k3: mapping reasoning_effort '{}' to supported value '{}'",
+                    effort, mapped
+                );
+                self.reasoning_effort = Some(mapped.to_string());
+            }
+            None => {
+                warn!(
+                    "kimi-k3: stripping unsupported reasoning_effort '{}' from upstream request",
+                    effort
+                );
+                self.reasoning_effort = None;
+            }
+        }
+    }
+
+    /// Strip sampling fields that the Kimi K3 API pins to fixed values and asks
+    /// callers to omit (`temperature`, `top_p`, `n`, `presence_penalty`,
+    /// `frequency_penalty`), and coerce `reasoning_effort` to a supported value.
+    pub fn normalize_for_kimi_k3_api(&mut self) {
+        if self.temperature.is_some() {
+            warn!("kimi-k3: stripping fixed temperature from upstream request");
+            self.temperature = None;
+        }
+        if self.top_p.is_some() {
+            warn!("kimi-k3: stripping fixed top_p from upstream request");
+            self.top_p = None;
+        }
+        if self.n.is_some() {
+            warn!("kimi-k3: stripping fixed n from upstream request");
+            self.n = None;
+        }
+        if self.presence_penalty.is_some() {
+            warn!("kimi-k3: stripping fixed presence_penalty from upstream request");
+            self.presence_penalty = None;
+        }
+        if self.frequency_penalty.is_some() {
+            warn!("kimi-k3: stripping fixed frequency_penalty from upstream request");
+            self.frequency_penalty = None;
+        }
+        self.normalize_kimi_k3_reasoning_effort();
+    }
+
     /// True when any message content part already carries a `cache_control` marker
     /// (client-supplied or previously injected).
     pub fn has_cache_control_markers(&self) -> bool {
@@ -274,6 +334,12 @@ fn attach_cache_control(message: &mut Message, marker: CacheControl) -> bool {
 /// True when the upstream model id is Moonshot's Kimi Code endpoint model.
 pub fn is_kimi_code_model(model: &str) -> bool {
     model == "kimi-for-coding"
+}
+
+/// True when the upstream model id is a Kimi K3 model, including dated and
+/// suffixed variants (e.g. `kimi-k3-0716`).
+pub fn is_kimi_k3_model(model: &str) -> bool {
+    model == "kimi-k3" || model.starts_with("kimi-k3-")
 }
 
 // ============================================================================
@@ -954,6 +1020,65 @@ impl ProviderStreamResponse for ChatCompletionsStreamResponse {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_is_kimi_k3_model_matches_base_and_dated_variants() {
+        assert!(is_kimi_k3_model("kimi-k3"));
+        assert!(is_kimi_k3_model("kimi-k3-0716"));
+        assert!(!is_kimi_k3_model("kimi-k2.6"));
+        assert!(!is_kimi_k3_model("kimi-for-coding"));
+        assert!(!is_kimi_k3_model("moonshotai/kimi-k3"));
+    }
+
+    #[test]
+    fn test_normalize_for_kimi_k3_maps_reasoning_effort_to_supported_values() {
+        // K3 cannot disable thinking, so anything below `low` collapses onto it.
+        for effort in ["none", "minimal", "low"] {
+            let mut req = ChatCompletionsRequest {
+                model: "kimi-k3".to_string(),
+                reasoning_effort: Some(effort.to_string()),
+                ..Default::default()
+            };
+            req.normalize_for_kimi_k3_api();
+            assert_eq!(req.reasoning_effort.as_deref(), Some("low"), "{}", effort);
+        }
+
+        // OpenAI's `medium` has no K3 equivalent; `high` is the nearest level.
+        for effort in ["medium", "high", "HIGH"] {
+            let mut req = ChatCompletionsRequest {
+                model: "kimi-k3".to_string(),
+                reasoning_effort: Some(effort.to_string()),
+                ..Default::default()
+            };
+            req.normalize_for_kimi_k3_api();
+            assert_eq!(req.reasoning_effort.as_deref(), Some("high"), "{}", effort);
+        }
+
+        let mut req = ChatCompletionsRequest {
+            model: "kimi-k3".to_string(),
+            reasoning_effort: Some("max".to_string()),
+            ..Default::default()
+        };
+        req.normalize_for_kimi_k3_api();
+        assert_eq!(req.reasoning_effort.as_deref(), Some("max"));
+
+        // Unrecognized values are dropped so the upstream default applies.
+        let mut req = ChatCompletionsRequest {
+            model: "kimi-k3".to_string(),
+            reasoning_effort: Some("turbo".to_string()),
+            ..Default::default()
+        };
+        req.normalize_for_kimi_k3_api();
+        assert!(req.reasoning_effort.is_none());
+
+        // An absent value stays absent.
+        let mut req = ChatCompletionsRequest {
+            model: "kimi-k3".to_string(),
+            ..Default::default()
+        };
+        req.normalize_for_kimi_k3_api();
+        assert!(req.reasoning_effort.is_none());
+    }
 
     /// Build a request with a long system prompt (well over the token threshold) plus
     /// a short user turn.

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -336,10 +336,14 @@ pub fn is_kimi_code_model(model: &str) -> bool {
     model == "kimi-for-coding"
 }
 
-/// True when the upstream model id is a Kimi K3 model, including dated and
-/// suffixed variants (e.g. `kimi-k3-0716`).
+/// True when the upstream model id is Moonshot's Kimi K3 model.
+///
+/// Matches the exact id only. Moonshot versions the Kimi line with dotted minor
+/// releases (`kimi-k2.5`, `kimi-k2.6`), so a future `kimi-k3.1` will need to be
+/// added here explicitly once its parameter constraints are known, rather than
+/// assumed to match K3's.
 pub fn is_kimi_k3_model(model: &str) -> bool {
-    model == "kimi-k3" || model.starts_with("kimi-k3-")
+    model == "kimi-k3"
 }
 
 // ============================================================================
@@ -1022,11 +1026,23 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_is_kimi_k3_model_matches_base_and_dated_variants() {
+    fn test_is_kimi_k3_model_matches_the_exact_id_only() {
         assert!(is_kimi_k3_model("kimi-k3"));
-        assert!(is_kimi_k3_model("kimi-k3-0716"));
+
+        // Moonshot versions the Kimi line with dotted minor releases, so these are
+        // the spellings a future K3 variant would plausibly use. They deliberately
+        // do not match: whoever adds one has to confirm it shares K3's pinned
+        // sampling params and reasoning_effort levels first.
+        assert!(!is_kimi_k3_model("kimi-k3.1"));
+        assert!(!is_kimi_k3_model("kimi-k3.5"));
+        assert!(!is_kimi_k3_model("kimi-k3-0716"));
+
+        // Neighbouring Kimi models must never be caught by a loosened matcher.
         assert!(!is_kimi_k3_model("kimi-k2.6"));
+        assert!(!is_kimi_k3_model("kimi-k2.5"));
         assert!(!is_kimi_k3_model("kimi-for-coding"));
+
+        // The provider prefix is stripped before normalization runs.
         assert!(!is_kimi_k3_model("moonshotai/kimi-k3"));
     }
 

--- a/crates/hermesllm/src/bin/provider_models.yaml
+++ b/crates/hermesllm/src/bin/provider_models.yaml
@@ -183,6 +183,7 @@ providers:
   - mistralai/codestral-embed
   - mistralai/codestral-embed-2505
   moonshotai:
+  - moonshotai/kimi-k3
   - moonshotai/kimi-k2.5
   - moonshotai/kimi-k2.6
   - moonshotai/moonshot-v1-32k

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -757,6 +757,15 @@ mod tests {
     }
 
     #[test]
+    fn test_moonshotai_models_include_kimi_k3() {
+        let models = ProviderId::Moonshotai.models();
+        assert!(
+            models.iter().any(|m| m == "kimi-k3"),
+            "moonshotai models should include kimi-k3"
+        );
+    }
+
+    #[test]
     fn test_minimax_parsing_and_models() {
         assert_eq!(ProviderId::try_from("minimax"), Ok(ProviderId::Minimax));
         assert_eq!(ProviderId::Minimax.to_string(), "minimax");

--- a/crates/hermesllm/src/providers/request.rs
+++ b/crates/hermesllm/src/providers/request.rs
@@ -1,5 +1,5 @@
 use crate::apis::anthropic::MessagesRequest;
-use crate::apis::openai::{is_kimi_code_model, ChatCompletionsRequest};
+use crate::apis::openai::{is_kimi_code_model, is_kimi_k3_model, ChatCompletionsRequest};
 use log::warn;
 
 use crate::apis::amazon_bedrock::{ConverseRequest, ConverseStreamRequest};
@@ -98,6 +98,11 @@ impl ProviderRequestType {
             if let Self::ChatCompletionsRequest(req) = self {
                 if is_kimi_code_model(req.model()) {
                     req.normalize_for_kimi_code_api();
+                }
+                // Moonshot's own API pins these sampling fields; aggregators that
+                // resell K3 still accept them, so only strip for the first party.
+                if provider_id == ProviderId::Moonshotai && is_kimi_k3_model(req.model()) {
+                    req.normalize_for_kimi_k3_api();
                 }
             } else if let Self::MessagesRequest(req) = self {
                 if is_kimi_code_model(req.model.as_str()) && req.thinking.is_some() {
@@ -932,6 +937,79 @@ mod tests {
         assert!(req.stream_options.is_none());
         assert!(req.reasoning_effort.is_none());
         assert!(req.web_search_options.is_none());
+    }
+
+    #[test]
+    fn test_normalize_for_upstream_kimi_k3_strips_fixed_sampling_fields() {
+        use crate::apis::openai::{Message, MessageContent, OpenAIApi, Role};
+
+        let mut request = ProviderRequestType::ChatCompletionsRequest(ChatCompletionsRequest {
+            model: "kimi-k3".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Some(MessageContent::Text("hello".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            temperature: Some(0.2),
+            top_p: Some(0.1),
+            n: Some(2),
+            presence_penalty: Some(0.5),
+            frequency_penalty: Some(0.5),
+            reasoning_effort: Some("max".to_string()),
+            ..Default::default()
+        });
+
+        request
+            .normalize_for_upstream(
+                ProviderId::Moonshotai,
+                &SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
+            )
+            .unwrap();
+
+        let ProviderRequestType::ChatCompletionsRequest(req) = request else {
+            panic!("expected chat request");
+        };
+        assert!(req.temperature.is_none());
+        assert!(req.top_p.is_none());
+        assert!(req.n.is_none());
+        assert!(req.presence_penalty.is_none());
+        assert!(req.frequency_penalty.is_none());
+        // K3 is always thinking; reasoning_effort is the supported control.
+        assert_eq!(req.reasoning_effort.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn test_normalize_for_upstream_kimi_k3_via_aggregator_keeps_sampling_fields() {
+        use crate::apis::openai::{Message, MessageContent, OpenAIApi, Role};
+
+        let mut request = ProviderRequestType::ChatCompletionsRequest(ChatCompletionsRequest {
+            model: "moonshotai/kimi-k3".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Some(MessageContent::Text("hello".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            temperature: Some(0.2),
+            top_p: Some(0.1),
+            ..Default::default()
+        });
+
+        request
+            .normalize_for_upstream(
+                ProviderId::OpenRouter,
+                &SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions),
+            )
+            .unwrap();
+
+        let ProviderRequestType::ChatCompletionsRequest(req) = request else {
+            panic!("expected chat request");
+        };
+        assert_eq!(req.temperature, Some(0.2));
+        assert_eq!(req.top_p, Some(0.1));
     }
 
     #[test]

--- a/docs/source/concepts/llm_providers/supported_providers.rst
+++ b/docs/source/concepts/llm_providers/supported_providers.rst
@@ -437,9 +437,12 @@ Moonshot AI
    * - Kimi for Coding
      - ``moonshotai/kimi-for-coding``
      - Kimi Code API model for agentic coding (use with ``base_url: https://api.kimi.com/coding/v1``)
-   * - Kimi K2 Preview
-     - ``moonshotai/kimi-k2-0905-preview``
-     - Foundation model optimized for agentic tasks with 32B activated parameters
+   * - Kimi K2.6
+     - ``moonshotai/kimi-k2.6``
+     - Latest K2-line foundation model optimized for agentic tasks
+   * - Kimi K2.5
+     - ``moonshotai/kimi-k2.5``
+     - Previous K2-line foundation model optimized for agentic tasks
    * - Moonshot v1 32K
      - ``moonshotai/moonshot-v1-32k``
      - Extended context model with 32K tokens
@@ -464,7 +467,7 @@ Moonshot AI
           User-Agent: "KimiCLI/1.3"
 
       # Latest K2 models for agentic tasks
-      - model: moonshotai/kimi-k2-0905-preview
+      - model: moonshotai/kimi-k2.6
         access_key: $MOONSHOTAI_API_KEY
 
       # V1 models with different context lengths

--- a/docs/source/concepts/llm_providers/supported_providers.rst
+++ b/docs/source/concepts/llm_providers/supported_providers.rst
@@ -422,7 +422,7 @@ Moonshot AI
 
 **Authentication:** API Key - Get your Moonshot AI API key from `Moonshot AI Platform <https://platform.moonshot.ai/>`_.
 
-**Supported Chat Models:** All Moonshot AI chat models including Kimi K2, Moonshot v1, and all future releases.
+**Supported Chat Models:** All Moonshot AI chat models including Kimi K3, Kimi K2, Moonshot v1, and all future releases.
 
 .. list-table::
    :header-rows: 1
@@ -431,6 +431,9 @@ Moonshot AI
    * - Model Name
      - Model ID for Config
      - Description
+   * - Kimi K3
+     - ``moonshotai/kimi-k3``
+     - Flagship multimodal reasoning model with a 1M-token context window
    * - Kimi for Coding
      - ``moonshotai/kimi-for-coding``
      - Kimi Code API model for agentic coding (use with ``base_url: https://api.kimi.com/coding/v1``)
@@ -449,6 +452,10 @@ Moonshot AI
 .. code-block:: yaml
 
     llm_providers:
+      # Flagship reasoning model with a 1M-token context window
+      - model: moonshotai/kimi-k3
+        access_key: $MOONSHOTAI_API_KEY
+
       # Kimi Code API (Claude Code / agentic clients via Plano translation)
       - model: moonshotai/kimi-for-coding
         access_key: $MOONSHOTAI_API_KEY
@@ -466,6 +473,16 @@ Moonshot AI
 
       - model: moonshotai/moonshot-v1-128k
         access_key: $MOONSHOTAI_API_KEY
+
+.. note::
+
+   Kimi K3 always runs in thinking mode and pins ``temperature``, ``top_p``, ``n``,
+   ``presence_penalty``, and ``frequency_penalty`` to fixed values. Plano strips these
+   fields from requests sent to Moonshot's API so clients that set them do not fail.
+   Use the ``reasoning_effort`` field to control reasoning depth instead. K3 accepts
+   ``low``, ``high``, and ``max`` (default ``max``); Plano maps other OpenAI-style
+   values onto the nearest supported level, so ``none`` and ``minimal`` become ``low``
+   and ``medium`` becomes ``high``.
 
 
 Zhipu AI


### PR DESCRIPTION
## Summary

- Registers `moonshotai/kimi-k3` in `provider_models.yaml`, so it expands under `moonshotai/*` wildcards and appears in the models list endpoint.
- Adds `normalize_for_kimi_k3_api`, following the existing `normalize_for_kimi_code_api` pattern. Moonshot pins `temperature`, `top_p`, `n`, `presence_penalty`, and `frequency_penalty` for K3 and asks callers to omit them, so those fields are stripped rather than forwarded into a rejection. `reasoning_effort` is coerced onto the values K3 accepts (`low`, `high`, `max`): `none`/`minimal` collapse onto `low` since K3 cannot disable thinking, `medium` maps to `high`, and unrecognized values are dropped so Moonshot's own default applies.
- Gates the normalization on `ProviderId::Moonshotai`. The constraint belongs to Moonshot's first-party API, not to the weights, so K3 served through OpenRouter or DigitalOcean still passes sampling params through untouched.
- Documents K3 in the Moonshot provider section, and refreshes the stale K2 model ids there (`kimi-k2-0905-preview` no longer exists in the provider model list; it is now `kimi-k2.5`/`kimi-k2.6`).

## Note on the first commit

`cb02e96d` regenerates `crates/Cargo.lock`, which is unrelated to K3 but was required to commit at all. The earlier dependency security bump (#1001) raised `serde_with` to `3.21.0` and `tokio-postgres` to `0.7.18` in the `Cargo.toml` files without regenerating the lock, which still pinned `3.18.0` and `0.7.17`. As a result `cargo clippy --locked` fails on `main`, both in CI and in the `cargo-clippy` pre-commit hook. It is kept as a separate commit so it can be cherry-picked on its own if you want to unblock CI independently of this PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (456 tests, 0 failures)
- [x] New coverage: fixed sampling fields stripped for first-party Moonshot; preserved when the same model is routed via an aggregator; `reasoning_effort` mapping across all input values; `kimi-k3` present in the Moonshot model list; `is_kimi_k3_model` matches dated variants like `kimi-k3-0716` but not `kimi-k2.6` or `kimi-for-coding`.
- [ ] Live smoke test against `api.moonshot.ai` with a real `MOONSHOTAI_API_KEY` (not run here; no key available). Worth confirming the `reasoning_effort` mapping against real API behavior, since the docs state which values K3 accepts without specifying how it responds to others.