### PR TITLE
fixed the name of the policy object from max_overhead_pct to max_swit…

### DIFF
--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -558,17 +558,17 @@ properties:
           context_tokens x (candidate_uncached_input_rate - anchor_cached_input_rate),
           output cost deliberately excluded — accrues into the session's cumulative
           switch spend. A paid switch is allowed only while that spend stays within
-          max_overhead_pct percent of the session's running never-switch baseline (what
+          max_switch_spend_pct percent of the session's running never-switch baseline (what
           staying on the anchor would have cost). An outright-cheaper switch is free but
           never reduces the spend. Requires a cost source in model_metrics_sources.
         properties:
-          max_overhead_pct:
+          max_switch_spend_pct:
             type: number
             minimum: 0
             description: >
-              Cap on cumulative switching overhead, as a percentage of what the session
+              Cap on cumulative switching spend, as a percentage of what the session
               would have cost by never switching (a whole number: 20 = 20%). The promise
-              is "this conversation bills at most max_overhead_pct% above never-switching."
+              is "this conversation bills at most max_switch_spend_pct% above never-switching."
               0 means never pay to switch (only outright-cheaper switches are allowed);
               larger values buy more quality-driven switches. Typical range 10-30.
           replenish_on_rebind:
@@ -589,7 +589,7 @@ properties:
               the switch been allowed, as the plano.switch.counterfactual_route span
               attribute. Telemetry only — the counterfactual model is never dispatched.
               Useful for evals/benchmarks. Default false.
-        required: ["max_overhead_pct"]
+        required: ["max_switch_spend_pct"]
         additionalProperties: false
     additionalProperties: false
   state_storage:

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -7,13 +7,13 @@
 //! * **Cache warmth** — inferred structurally from how long ago the session was last
 //!   used vs. the provider's cache window ([`hermesllm::provider_cache_capability`]),
 //!   so it works on the decision path with no provider response in hand.
-//! * **A cumulative per-session overhead cap** — a paid switch (the candidate must
+//! * **A cumulative per-session spend cap** — a paid switch (the candidate must
 //!   re-ingest the context at its uncached rate) is allowed only while total switch
-//!   spend stays within `max_overhead_pct`% of the session's running *never-switch*
+//!   spend stays within `max_switch_spend_pct`% of the session's running *never-switch*
 //!   baseline (what staying on the session's `default_model` would have cost — priced
 //!   independently of the current anchor, which drifts as switches happen). An
 //!   outright-cheaper switch is free but never reduces that spend. The promise: this
-//!   conversation bills at most `max_overhead_pct`% above never-switching. A warm
+//!   conversation bills at most `max_switch_spend_pct`% above never-switching. A warm
 //!   anchor is priced at its *cached* rate and the switch pays the cache-loss delta:
 //!   provider caches are assumed real whenever the budget is active (most providers
 //!   cache automatically), independent of `prompt_caching.enabled`, which only
@@ -298,9 +298,9 @@ pub async fn route(
                 decision_label = metric_labels::SWITCH_DECISION_ALLOWED;
                 reason = metric_labels::SWITCH_REASON_SAME_ANCHOR;
             } else if let Some(cfg) = routing_budget {
-                // Ceiling: at most `max_overhead_pct`% of the cumulative baseline may be
+                // Ceiling: at most `max_switch_spend_pct`% of the cumulative baseline may be
                 // spent on switching over this warm episode.
-                let ceiling = (cfg.max_overhead_pct / 100.0) * baseline_usd;
+                let ceiling = (cfg.max_switch_spend_pct / 100.0) * baseline_usd;
                 ceiling_opt = Some(ceiling);
                 // Credit any context the candidate still has cached from an earlier visit
                 // this session: a return to a still-warm model re-reads only the tokens
@@ -453,7 +453,7 @@ pub async fn route(
         ));
         if routing_budget.is_some() {
             // Consumed overhead as a percentage of the never-switch baseline — directly
-            // comparable to the configured max_overhead_pct. Zero before any baseline.
+            // comparable to the configured max_switch_spend_pct. Zero before any baseline.
             let overhead_pct = if baseline_usd > 0.0 {
                 100.0 * switch_spend_usd / baseline_usd
             } else {
@@ -662,7 +662,7 @@ mod tests {
 
     fn routing_budget(pct: f64) -> EffectiveRoutingBudget {
         EffectiveRoutingBudget {
-            max_overhead_pct: pct,
+            max_switch_spend_pct: pct,
             replenish_on_rebind: true,
             cache_read_discount: 0.1,
             record_counterfactual: false,
@@ -888,7 +888,7 @@ mod tests {
 
     /// End-to-end cost validation over a full session lifetime: drive `route()` turn by
     /// turn through the real session cache and pricing math, and check the feature's core
-    /// promise at every turn — cumulative switch spend never exceeds `max_overhead_pct`%
+    /// promise at every turn — cumulative switch spend never exceeds `max_switch_spend_pct`%
     /// of the never-switch baseline.
     ///
     /// With a 100k context, each warm turn grows the baseline by 100k x $0.30/M = $0.03
@@ -932,7 +932,7 @@ mod tests {
                 d.switch_spend_usd <= cap_fraction * d.baseline_usd + 1e-9,
                 "turn {turn}: spend {} exceeds {}% of baseline {}",
                 d.switch_spend_usd,
-                st.max_overhead_pct,
+                st.max_switch_spend_pct,
                 d.baseline_usd
             );
             // Baseline must track the independently computed never-switch cost:
@@ -991,7 +991,7 @@ mod tests {
         );
 
         // Final end-to-end check of the promise: total switch overhead across the whole
-        // session is within max_overhead_pct% of the independently computed
+        // session is within max_switch_spend_pct% of the independently computed
         // never-switch baseline.
         let never_switch_cost = 0.03 * warm_turns as f64;
         assert!(
@@ -1003,7 +1003,7 @@ mod tests {
             d.switch_spend_usd <= cap_fraction * d.baseline_usd + 1e-9,
             "session overhead {} exceeds the promised {}% of {}",
             d.switch_spend_usd,
-            st.max_overhead_pct,
+            st.max_switch_spend_pct,
             d.baseline_usd
         );
     }

--- a/crates/brightstaff/src/tracing/constants.rs
+++ b/crates/brightstaff/src/tracing/constants.rs
@@ -173,7 +173,7 @@ pub mod plano {
 
     /// Cumulative switching overhead consumed this session, as a percentage of the
     /// never-switch baseline (`100 * switch_spend / baseline`). Directly comparable to
-    /// the configured `routing.routing_budget.max_overhead_pct`.
+    /// the configured `routing.routing_budget.max_switch_spend_pct`.
     pub const SESSION_OVERHEAD_PCT: &str = "plano.session.overhead_pct";
 
     /// Cumulative overhead (USD) actually spent on paid switches this session — the
@@ -205,7 +205,7 @@ pub mod plano {
     pub const SWITCH_CANDIDATE_WARM_TOKENS: &str = "plano.switch.candidate_warm_tokens";
 
     /// The overhead ceiling (USD) available when the switch was evaluated —
-    /// `max_overhead_pct% * baseline`. A paid switch is allowed while cumulative spend
+    /// `max_switch_spend_pct% * baseline`. A paid switch is allowed while cumulative spend
     /// plus this switch's cost stays under it. Directly comparable to `cost_in_usd`.
     pub const SWITCH_OVERHEAD_CEILING_IN_USD: &str = "plano.switch.overhead_ceiling_in_usd";
 

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -291,7 +291,7 @@ pub struct PromptCaching {
 /// caching there is no warm cache to lose, so it is
 /// `context_tokens x (candidate_uncached_input_rate - anchor_uncached_input_rate)`. That
 /// input-token cost accrues into the session's cumulative switch spend. The gate allows a paid switch
-/// only while that spend stays within `max_overhead_pct` percent of the session's
+/// only while that spend stays within `max_switch_spend_pct` percent of the session's
 /// running *never-switch* baseline (the cost the session would have paid by staying
 /// on its anchor). A switch that is outright cheaper (negative cost) is free but
 /// never credits the spend back — the "saving" is vs a path we didn't take, not real
@@ -299,12 +299,12 @@ pub struct PromptCaching {
 /// rates are available. Presence of the block turns it on.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct RoutingBudget {
-    /// Cap on cumulative switching overhead, as a **percentage** of what the session
+    /// Cap on cumulative switching spend, as a **percentage** of what the session
     /// would have cost by never switching (a whole number: `20` = 20%). The promise
-    /// is "this conversation bills at most `max_overhead_pct`% above never-switching."
+    /// is "this conversation bills at most `max_switch_spend_pct`% above never-switching."
     /// `0` means "never pay to switch" (only outright-cheaper switches are ever
     /// allowed); larger values buy more quality-driven switches. Typical range 10–30.
-    pub max_overhead_pct: f64,
+    pub max_switch_spend_pct: f64,
     /// Reset the running baseline/spend totals when a session goes cold and re-binds
     /// (a fresh warm episode). Defaults to `true`.
     #[serde(default = "default_true")]
@@ -332,7 +332,7 @@ fn default_true() -> bool {
 pub struct EffectiveRoutingBudget {
     /// Cumulative switching-overhead cap, as a percentage of the never-switch
     /// baseline (a whole number: `20` = 20%).
-    pub max_overhead_pct: f64,
+    pub max_switch_spend_pct: f64,
     /// Reset the running baseline/spend totals on cold->warm re-bind.
     pub replenish_on_rebind: bool,
     pub cache_read_discount: f64,
@@ -346,10 +346,10 @@ impl RoutingBudget {
     /// Resolve to effective settings, validating the overhead cap and cache-read
     /// discount.
     pub fn resolve(&self) -> Result<EffectiveRoutingBudget, String> {
-        if !self.max_overhead_pct.is_finite() || self.max_overhead_pct < 0.0 {
+        if !self.max_switch_spend_pct.is_finite() || self.max_switch_spend_pct < 0.0 {
             return Err(format!(
-                "routing.routing_budget.max_overhead_pct: must be a non-negative number (percent, e.g. 20 for 20%), got {}",
-                self.max_overhead_pct
+                "routing.routing_budget.max_switch_spend_pct: must be a non-negative number (percent, e.g. 20 for 20%), got {}",
+                self.max_switch_spend_pct
             ));
         }
         let cache_read_discount = self
@@ -361,7 +361,7 @@ impl RoutingBudget {
             ));
         }
         Ok(EffectiveRoutingBudget {
-            max_overhead_pct: self.max_overhead_pct,
+            max_switch_spend_pct: self.max_switch_spend_pct,
             replenish_on_rebind: self.replenish_on_rebind,
             cache_read_discount,
             record_counterfactual: self.record_counterfactual,
@@ -1152,11 +1152,11 @@ inject_cache_control: true
     #[test]
     fn test_routing_budget_parses() {
         let yaml = r#"
-max_overhead_pct: 20
+max_switch_spend_pct: 20
 "#;
         let cfg: RoutingBudget = serde_yaml::from_str(yaml).unwrap();
         let budget = cfg.resolve().unwrap();
-        assert_eq!(budget.max_overhead_pct, 20.0);
+        assert_eq!(budget.max_switch_spend_pct, 20.0);
         // Replenish defaults on.
         assert!(budget.replenish_on_rebind);
         assert_eq!(budget.cache_read_discount, DEFAULT_CACHE_READ_DISCOUNT);
@@ -1167,7 +1167,7 @@ max_overhead_pct: 20
     #[test]
     fn test_routing_budget_record_counterfactual_parses() {
         let yaml = r#"
-max_overhead_pct: 20
+max_switch_spend_pct: 20
 record_counterfactual: true
 "#;
         let cfg: RoutingBudget = serde_yaml::from_str(yaml).unwrap();
@@ -1178,13 +1178,13 @@ record_counterfactual: true
     #[test]
     fn test_routing_budget_flags_parse() {
         let yaml = r#"
-max_overhead_pct: 15
+max_switch_spend_pct: 15
 replenish_on_rebind: false
 cache_read_discount: 0.25
 "#;
         let cfg: RoutingBudget = serde_yaml::from_str(yaml).unwrap();
         let budget = cfg.resolve().unwrap();
-        assert_eq!(budget.max_overhead_pct, 15.0);
+        assert_eq!(budget.max_switch_spend_pct, 15.0);
         assert!(!budget.replenish_on_rebind);
         assert_eq!(budget.cache_read_discount, 0.25);
     }
@@ -1197,12 +1197,12 @@ cache_read_discount: 0.25
 
     #[test]
     fn test_routing_budget_invalid_values_rejected() {
-        let negative: RoutingBudget = serde_yaml::from_str("max_overhead_pct: -1.0").unwrap();
+        let negative: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: -1.0").unwrap();
         assert!(negative.resolve().is_err());
 
         let bad_discount: RoutingBudget = serde_yaml::from_str(
             r#"
-max_overhead_pct: 20
+max_switch_spend_pct: 20
 cache_read_discount: 1.5
 "#,
         )

--- a/demos/llm_routing/routing_budget/GUIDE.md
+++ b/demos/llm_routing/routing_budget/GUIDE.md
@@ -8,7 +8,7 @@ There are two independent behaviors to observe:
   warm, so per-turn input cost drops sharply across a multi-turn conversation.
 2. **Routing budget** — the router still runs every turn, but when it proposes a
   *different* model while the session's cache is plausibly warm, Plano only switches
-  while the session's cumulative switch spend stays within `max_overhead_pct`% of what
+  while the session's cumulative switch spend stays within `max_switch_spend_pct`% of what
   staying put would have cost. This is a routing concern and is self-sufficient:
   it needs no `prompt_caching` config (it derives sessions and prices warm
   anchors at cached rates on its own).
@@ -56,7 +56,7 @@ model_metrics_sources:
 
 routing:
   routing_budget:                 # no default — presence turns it on
-    max_overhead_pct: 20          # bill at most 20% above never-switching
+    max_switch_spend_pct: 20          # bill at most 20% above never-switching
     # replenish_on_rebind: true   # reset running totals when a cold session re-binds
     # cache_read_discount: 0.1    # fallback when a feed omits cache_read
 ```
@@ -164,7 +164,7 @@ To observe it:
 
 - **Vetoed switch (paid, over cap):** with a warm session on an expensive model
 and a large context, a switch to a pricier candidate would push the session's total
-switch spend past `max_overhead_pct`% of its never-switch baseline → Plano **retains**
+switch spend past `max_switch_spend_pct`% of its never-switch baseline → Plano **retains**
 the anchor.
 - **Paid switch (within cap):** the same switch while the spend still fits under the
 cap → Plano **switches** and adds `switch_cost` to the session's cumulative spend.
@@ -263,7 +263,7 @@ switch vetoed — would exceed session overhead cap, retaining anchor
 ```
 
 The switch would cost ~$3.96e-5 to re-read the context on `gpt-4o`, but only
-~$1.08e-6 of overhead was affordable (`max_overhead_pct`% of the still-tiny
+~$1.08e-6 of overhead was affordable (`max_switch_spend_pct`% of the still-tiny
 one-turn baseline) — so `.models[0]` stays `anthropic/claude-sonnet-4-6`. Confirm
 it with the metric:
 
@@ -276,7 +276,7 @@ brightstaff_session_switch_decisions_total{decision="retained",reason="over_cap"
 ```
 
 To see the **other** side, remove the `routing_budget` block (or set
-`max_overhead_pct` very high), restart, and repeat — turn 2 now returns
+`max_switch_spend_pct` very high), restart, and repeat — turn 2 now returns
 `"model": "openai/gpt-4o"` and the metric reads `decision="allowed",reason="free"`.
 That before/after — same calls, one config line — is the whole point: the
 router's quality pick wins *unless* the budget says the warm cache it burns
@@ -297,7 +297,7 @@ Because this endpoint **shares the same session cache and the same
 `session_router::route()` logic** as the full-proxy path, the two are fully
 interoperable: a session pinned via `/routing` is honored by a later
 `/v1/chat/completions` call (and vice versa), including the exact same
-`max_overhead_pct` gating. This is also why warmth here is inferred purely
+`max_switch_spend_pct` gating. This is also why warmth here is inferred purely
 from idle-time vs. the provider's cache window rather than a cache-hit signal
 — this path never has a provider response to read one from.
 
@@ -328,9 +328,9 @@ curl -s localhost:9092/metrics | grep -E 'session_switch_decisions|prompt_cache_
 - `plano.cache.idle_ms` — how long since the session was last used
 - `plano.switch.cost_in_usd` — actual input-token cost of the proposed switch (output excluded)
 - `plano.switch.candidate_warm_tokens` — context the candidate still has cached from an earlier visit this session (a return to a warm model re-reads only the delta, so its `cost_in_usd` is far lower than a full re-ingest)
-- `plano.switch.overhead_ceiling_in_usd` — overhead ceiling (`max_overhead_pct`% x baseline) when the switch was evaluated
+- `plano.switch.overhead_ceiling_in_usd` — overhead ceiling (`max_switch_spend_pct`% x baseline) when the switch was evaluated
 - `plano.switch.decision` — `allowed` or `retained`
-- `plano.session.overhead_pct` — cumulative switching overhead consumed, as a % of the never-switch baseline (compare directly to `max_overhead_pct`)
+- `plano.session.overhead_pct` — cumulative switching overhead consumed, as a % of the never-switch baseline (compare directly to `max_switch_spend_pct`)
 - `plano.session.switch_spend_in_usd` — cumulative $ actually spent on switches this session
 - `plano.session.baseline_in_usd` — cumulative $ staying on the anchor would have cost (the denominator)
 - `plano.session.switches` — switches taken so far this session
@@ -393,7 +393,7 @@ curl -s localhost:12000/v1/chat/completions \
 
 | Setting                                          | Effect                                                                          |
 | ------------------------------------------------ | ------------------------------------------------------------------------------- |
-| `routing.routing_budget.max_overhead_pct`        | Switching overhead cap as a % of never-switching (higher = quality-first, more switching) |
+| `routing.routing_budget.max_switch_spend_pct`        | Switching overhead cap as a % of never-switching (higher = quality-first, more switching) |
 | `routing.routing_budget.replenish_on_rebind`     | Reset the running baseline/spend totals when a cold session re-binds            |
 | `routing.routing_budget.cache_read_discount`     | Assumed cached rate for models whose feed entry omits a cached-read rate       |
 | `routing.routing_budget.record_counterfactual`   | Emit `plano.switch.counterfactual_route` on vetoed switches (the road not taken)|
@@ -414,4 +414,4 @@ the quality call; the overhead cap only vetoes a switch that the session can't a
 - The routing budget is independent of prompt caching (it lives under `routing`,
 needs no `prompt_caching` config, and always prices warm anchors at cached rates)
 and is fully opt-in with **no baked-in cap**: configuring it without a
-`max_overhead_pct` (or without a cost source) fails startup with a clear message.
+`max_switch_spend_pct` (or without a cost source) fails startup with a clear message.

--- a/demos/llm_routing/routing_budget/README.md
+++ b/demos/llm_routing/routing_budget/README.md
@@ -17,9 +17,9 @@ the cached rate you abandoned.
 The router runs every turn (routing stays cache-blind). When it proposes a model
 that differs from the session's warm anchor, Plano computes the **actual
 input-token cost** of abandoning the anchor's cache and only allows the switch
-while the session's cumulative switch spend stays within `max_overhead_pct`% of
+while the session's cumulative switch spend stays within `max_switch_spend_pct`% of
 what never-switching would have cost — otherwise it retains the warm anchor. The
-promise: the conversation bills at most `max_overhead_pct`% above never-switching.
+promise: the conversation bills at most `max_switch_spend_pct`% above never-switching.
 
 Quality and cost stay separate — the router still picks the best model; the
 budget only vetoes switches the session can't afford. Prompt caching

--- a/demos/llm_routing/routing_budget/config.yaml
+++ b/demos/llm_routing/routing_budget/config.yaml
@@ -23,20 +23,6 @@ model_providers:
       - name: code generation
         description: generating new code snippets, functions, or boilerplate based on user prompts or requirements
 
-# Plano needs to know what each model costs (regular price + cached price) to
-# do the switch-cost math below.
-model_metrics_sources:
-  - type: cost
-    provider: models.dev
-    refresh_interval: 86400
-
-# Not required. The routing budget already tracks sessions and cached pricing
-# on its own. Only turn this on if you also want Plano to inject cache-control
-# markers on the full-proxy path, or want session stickiness without a budget
-# — see GUIDE.md §4.
-# prompt_caching:
-#   enabled: true
-
 routing:
   # Caps how much extra you'll pay to switch models mid-conversation. See
   # GUIDE.md for the full walkthrough.
@@ -58,6 +44,13 @@ routing:
     # (as `plano.switch.counterfactual_route` in traces) so you can see what
     # you're missing out on. Doesn't actually call that model. Default false.
     record_counterfactual: true
+  
+# Plano needs to know what each model costs (regular price + cached price) to
+# do the switch-cost math below.
+model_metrics_sources:
+  - type: cost
+    provider: models.dev
+    refresh_interval: 86400
 
 tracing:
   random_sampling: 100

--- a/demos/llm_routing/routing_budget/config.yaml
+++ b/demos/llm_routing/routing_budget/config.yaml
@@ -36,15 +36,11 @@ routing:
     # spent and start counting from zero. Default true.
     # replenish_on_rebind: true
 
-    # If we don't know a model's cached price, guess it's this fraction of its
-    # regular price. Default 0.1 (i.e. 10%).
-    # cache_read_discount: 0.1
-
     # When Plano blocks a switch, also log what it *would* have switched to
     # (as `plano.switch.counterfactual_route` in traces) so you can see what
     # you're missing out on. Doesn't actually call that model. Default false.
     record_counterfactual: true
-  
+
 # Plano needs to know what each model costs (regular price + cached price) to
 # do the switch-cost math below.
 model_metrics_sources:

--- a/demos/llm_routing/routing_budget/config.yaml
+++ b/demos/llm_routing/routing_budget/config.yaml
@@ -23,71 +23,40 @@ model_providers:
       - name: code generation
         description: generating new code snippets, functions, or boilerplate based on user prompts or requirements
 
-# Per-model pricing is required for the routing budget: the switch-cost
-# calculation needs each model's input and cached-input rates. This demo reads
-# DigitalOcean's managed pricing catalog, which publishes cached-read rates
-# (`cache_read_input_price_per_million` / `input_cache_read`). The catalog is
-# keyed by bare DO model ids (e.g. `openai-gpt-4o`), so model_aliases maps them
-# onto the Plano model names used in model_providers above — without the
-# mapping no rates match and every switch decision fails open (no_pricing).
+# Plano needs to know what each model costs (regular price + cached price) to
+# do the switch-cost math below.
 model_metrics_sources:
   - type: cost
-    provider: digitalocean
+    provider: models.dev
     refresh_interval: 86400
-    model_aliases:
-      openai-gpt-4o-mini: openai/gpt-4o-mini
-      openai-gpt-4o: openai/gpt-4o
-      anthropic-claude-4.6-sonnet: anthropic/claude-sonnet-4-6
 
-  # models.dev works identically and needs no aliases (its keys already match
-  # the provider/model routing names). Rates for these models are the same on
-  # both feeds, so the walkthrough numbers in GUIDE.md hold either way.
-  # - type: cost
-  #   provider: models.dev
-  #   refresh_interval: 86400
-
-# Automatic prompt caching (opt-in). OPTIONAL for the routing budget: the budget
-# derives sessions and prices warm anchors at cached rates on its own. Enable this
-# only for what it adds — injecting cache-control markers on the full-proxy path
-# (required for the provider cache to be real on marker-based models like
-# anthropic/*; see GUIDE.md §4) and session affinity without a budget.
+# Not required. The routing budget already tracks sessions and cached pricing
+# on its own. Only turn this on if you also want Plano to inject cache-control
+# markers on the full-proxy path, or want session stickiness without a budget
+# — see GUIDE.md §4.
 # prompt_caching:
 #   enabled: true
 
 routing:
-  # Per-session cost gate on model switching. Independent of prompt caching: it
-  # applies whenever configured, and presence of this block turns it on. The
-  # default posture is to stick to the model a session is warm on. When routing
-  # proposes a *different* model while that session's provider cache is plausibly
-  # still warm (inferred from how long ago the session was last used vs. the
-  # provider's cache window), the actual input-token cost of abandoning the cache:
-  #
-  #   switch_cost = context_tokens x (candidate_uncached_input - anchor_cached_input)
-  #
-  # (output cost deliberately excluded) accrues into the session's cumulative switch
-  # spend. A paid switch is allowed only while that spend stays within max_overhead_pct
-  # percent of the session's running never-switch baseline (what staying on the anchor
-  # would have cost); an outright-cheaper switch is free but never reduces the spend.
-  # The cap is yours to define -- Plano never invents one, and startup fails without it
-  # (or without a cost source).
+  # Caps how much extra you'll pay to switch models mid-conversation. See
+  # GUIDE.md for the full walkthrough.
   routing_budget:
-    # Cap on cumulative switching overhead, as a percentage of what the session would
-    # have cost by never switching (a whole number: 20 = 20%). The promise is "this
-    # conversation bills at most 20% above never-switching." 0 means "never pay to
-    # switch"; larger values buy more switches before sticking. Typical range 10-30.
-    max_overhead_pct: 20
+    # How much extra (as a %) you're willing to pay to switch models, compared
+    # to what you'd have paid by just staying put. 0 = never pay to switch.
+    # Normal range: 10-30.
+    max_switch_spend_pct: 20
 
-    # Reset the running baseline/spend totals when a cold session re-binds. Default true.
+    # When a conversation goes cold and starts back up, forget what it already
+    # spent and start counting from zero. Default true.
     # replenish_on_rebind: true
 
-    # Fallback used only when the pricing feed doesn't publish a cached-read rate for
-    # a model: cached_rate = input_rate x cache_read_discount. Default 0.1.
+    # If we don't know a model's cached price, guess it's this fraction of its
+    # regular price. Default 0.1 (i.e. 10%).
     # cache_read_discount: 0.1
 
-    # Record the route the gate WOULD have taken when it vetoes a switch, as the
-    # `plano.switch.counterfactual_route` trace attribute. Telemetry only -- the
-    # counterfactual model is never dispatched. Handy for evals that want to
-    # measure the road not taken. Default false.
+    # When Plano blocks a switch, also log what it *would* have switched to
+    # (as `plano.switch.counterfactual_route` in traces) so you can see what
+    # you're missing out on. Doesn't actually call that model. Default false.
     record_counterfactual: true
 
 tracing:

--- a/demos/llm_routing/routing_budget/demo.sh
+++ b/demos/llm_routing/routing_budget/demo.sh
@@ -1,51 +1,152 @@
 #!/bin/bash
 set -e
 
-# Routing Budget demo — drives the /routing decision endpoint to show:
+# Routing Budget demo — drives the real /v1/chat/completions endpoint (the
+# same path production traffic takes) to show:
 #   1. implicit session pinning (same session across turns, going warm)
 #   2. the routing budget vetoing an unaffordable model switch
 #
-# Prereqs: `planoai up config.yaml` running, plus `curl` and `jq`.
+# Starts Plano itself with tracing enabled, then after each request prints
+# the matching trace via `planoai trace <trace_id>`, plus a second view
+# filtered down to just the `plano.*` attributes — session_id, cache warmth,
+# and the switch decision — so the pinning behavior is obvious without having
+# to know brightstaff's internals.
+#
+# We generate our own W3C `traceparent` header and send it on each request:
+# brightstaff only derives the `trace_id` it returns in the response body from
+# an incoming `traceparent` header (see extract_or_generate_traceparent in
+# crates/brightstaff/src/handlers/mod.rs) — without one, that field and the
+# real exported span end up with two independently-random, uncorrelated IDs.
+# Supplying our own keeps both in sync so we can look up the exact trace.
+#
+# Prereqs: `curl`, `jq`, `uuidgen`, and the `planoai` CLI on PATH.
 # See GUIDE.md for the full walkthrough and how to flip the veto into an allow.
 
 PLANO_URL="${PLANO_URL:-http://localhost:12000}"
 METRICS_URL="${METRICS_URL:-http://localhost:9092}"
 
+gen_trace_id() { uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-'; }
+gen_span_id() { uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-16; }
+
+# Poll for a specific trace_id to show up in the local OTLP listener, then
+# keep polling until its span count stops growing for two checks in a row.
+# Spans of the same trace can land in different OTLP batch-export flushes
+# (routing_decision's parent span can finish - and export - slightly after
+# its outbound child), so stopping at the first non-empty result can print a
+# partial trace that's missing the root span.
+wait_for_trace_by_id() {
+  local id="$1"
+  local tries=0
+  local last_count=-1
+  local stable_checks=0
+  while [ "$tries" -lt 30 ]; do
+    local json
+    json="$(planoai trace "$id" --json --no-interactive 2>/dev/null)"
+    local count
+    count="$(printf '%s' "$json" | jq '(.traces[0].spans // []) | length' 2>/dev/null)"
+    local has_root
+    has_root="$(printf '%s' "$json" | jq -e '(.traces[0].spans // []) | any(.service == "plano(llm)")' 2>/dev/null)"
+    if [ -n "$count" ] && [ "$count" -gt 0 ] 2>/dev/null && [ "$has_root" = "true" ]; then
+      if [ "$count" = "$last_count" ]; then
+        stable_checks=$((stable_checks + 1))
+        [ "$stable_checks" -ge 2 ] && return 0
+      else
+        stable_checks=0
+        last_count="$count"
+      fi
+    fi
+    sleep 0.5
+    tries=$((tries + 1))
+  done
+  return 1
+}
+
+# Right after startup, the very first outbound call can race Envoy/brightstaff
+# still finishing their upstream connection warmup and come back as a plain-text
+# "Failed to send request" instead of JSON. Poll with a throwaway request until
+# a real completion comes back before running the actual demo turns.
+wait_for_upstream_ready() {
+  local tries=0
+  while [ "$tries" -lt 20 ]; do
+    if curl -s "$PLANO_URL/v1/chat/completions" \
+        -H 'Content-Type: application/json' \
+        -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "ping"}]}' \
+        | jq -e '.model' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+    tries=$((tries + 1))
+  done
+  return 1
+}
+
 echo "=== Routing Budget Demo ==="
 echo ""
-echo "Uses the /routing/v1/chat/completions decision endpoint (no LLM call)."
-echo "Watch session_id stay stable and pinned flip false -> true, then watch"
-echo "the budget retain the warm anchor instead of following the router."
+echo "Starting Plano with tracing enabled (planoai up config.yaml --with-tracing)..."
+planoai up config.yaml --with-tracing
+trap 'echo ""; echo "Stopping Plano..."; planoai down' EXIT
+echo ""
+echo "Waiting for the upstream connection to warm up..."
+wait_for_upstream_ready || echo "    (still not ready, continuing anyway)"
+echo ""
+echo "Both turns hit the real /v1/chat/completions endpoint. Watch the"
+echo "'plano.*' trace attributes below each request: session_id stays the"
+echo "same across turns, plano.cache.warm flips false -> true, and"
+echo "plano.switch.decision shows whether the budget followed the router or"
+echo "retained the warm anchor."
 echo ""
 
 # --- Turn 1: pin the session (a code-generation prompt) ---
 echo "--- 1. Turn 1: pin the session (creates the binding) ---"
 echo ""
-curl -s "$PLANO_URL/routing/v1/chat/completions" \
+turn1_trace_id="$(gen_trace_id)"
+turn1_traceparent="00-${turn1_trace_id}-$(gen_span_id)-01"
+turn1_response="$(curl -s "$PLANO_URL/v1/chat/completions" \
   -H 'Content-Type: application/json' \
+  -H "traceparent: $turn1_traceparent" \
   -d '{"model": "openai/gpt-4o-mini", "messages": [
     {"role": "system", "content": "You are a senior Rust engineer."},
     {"role": "user", "content": "Write a Rust function that reverses a linked list."}
-  ]}' | jq '{model: .models[0], session_id, pinned}'
+  ]}')"
+printf '%s' "$turn1_response" | jq '{model, id}'
 echo ""
-echo "    Expect: model=anthropic/claude-sonnet-4-6, an implicit:… session_id, pinned=false"
+echo "    Expect: model=anthropic/claude-sonnet-4-6 (code generation)"
+echo ""
+echo "    Trace for turn 1 (trace_id=$turn1_trace_id, waiting for export)..."
+echo ""
+wait_for_trace_by_id "$turn1_trace_id" || true
+planoai trace "$turn1_trace_id"
+echo "    Session/pinning signal:"
+planoai trace "$turn1_trace_id" --filter "plano.*"
 echo ""
 
 # --- Turn 2: same system prompt + same first message, one turn later ---
 echo "--- 2. Turn 2: same session, warm, router proposes a different model ---"
 echo ""
-curl -s "$PLANO_URL/routing/v1/chat/completions" \
+turn2_trace_id="$(gen_trace_id)"
+turn2_traceparent="00-${turn2_trace_id}-$(gen_span_id)-01"
+turn2_response="$(curl -s "$PLANO_URL/v1/chat/completions" \
   -H 'Content-Type: application/json' \
+  -H "traceparent: $turn2_traceparent" \
   -d '{"model": "openai/gpt-4o-mini", "messages": [
     {"role": "system", "content": "You are a senior Rust engineer."},
     {"role": "user", "content": "Write a Rust function that reverses a linked list."},
     {"role": "assistant", "content": "Here is an idiomatic in-place reversal for a singly linked list:\n\n```rust\ntype Link = Option<Box<Node>>;\n\nstruct Node {\n    val: i32,\n    next: Link,\n}\n\nfn reverse(mut head: Link) -> Link {\n    let mut prev: Link = None;\n    while let Some(mut node) = head {\n        head = node.next.take();\n        node.next = prev;\n        prev = Some(node);\n    }\n    prev\n}\n```\n\nIt walks the list once, moving the next pointer of each node to its predecessor."},
     {"role": "user", "content": "Now explain its time complexity in plain English — no code."}
-  ]}' | jq '{model: .models[0], session_id, pinned}'
+  ]}')"
+printf '%s' "$turn2_response" | jq '{model, id}'
 echo ""
-echo "    Expect: SAME session_id as turn 1, pinned=true. If the router proposed"
-echo "    openai/gpt-4o (code understanding), the budget vetoed the switch and"
-echo "    model stays anthropic/claude-sonnet-4-6 (the warm anchor)."
+echo "    Expect: same model as turn 1 (anthropic/claude-sonnet-4-6). If the"
+echo "    router proposed openai/gpt-4o (code understanding) this turn, the"
+echo "    budget vetoed the switch and retained the warm anchor instead —"
+echo "    check plano.switch.decision below."
+echo ""
+echo "    Trace for turn 2 (trace_id=$turn2_trace_id, waiting for export)..."
+echo ""
+wait_for_trace_by_id "$turn2_trace_id" || true
+planoai trace "$turn2_trace_id"
+echo "    Session/pinning signal:"
+planoai trace "$turn2_trace_id" --filter "plano.*"
 echo ""
 
 # --- Switch decisions metric ---
@@ -61,6 +162,6 @@ echo ""
 echo "=== Demo Complete ==="
 echo ""
 echo "To see the switch ALLOWED instead of vetoed: comment out the routing_budget"
-echo "block in config.yaml (or raise max_overhead_pct), then 'planoai down &&"
+echo "block in config.yaml (or raise max_switch_spend_pct), then 'planoai down &&"
 echo "planoai up config.yaml' and re-run — turn 2 will follow the router to"
 echo "openai/gpt-4o. See GUIDE.md for details."

--- a/tests/e2e/run_model_alias_tests.sh
+++ b/tests/e2e/run_model_alias_tests.sh
@@ -36,8 +36,8 @@ uv sync
 # Start gateway with model alias routing config
 log "startup plano gateway with model alias routing demo"
 cd ../../
-planoai down --docker || true
-planoai up --docker demos/llm_routing/model_alias_routing/config_with_aliases.yaml
+planoai down || true
+planoai up demos/llm_routing/model_alias_routing/config_with_aliases.yaml
 cd -
 
 # Run both test suites that share this config in a single pytest invocation
@@ -46,4 +46,4 @@ uv run pytest -n auto test_model_alias_routing.py test_openai_responses_api_clie
 
 # Cleanup
 log "shutting down"
-planoai down --docker || true
+planoai down || true


### PR DESCRIPTION
…ch_spend_pct and updated the demo to show just the v1/chat/completions endpoint run