### PR TITLE
fix(trace): preserve the root trace ID when OTLP children arrive first

### DIFF
--- a/cli/planoai/trace_cmd.py
+++ b/cli/planoai/trace_cmd.py
@@ -359,6 +359,7 @@ class _TraceStore:
 
                 # Determine which group this span belongs to.
                 group_key: str | None = None
+                orphan_group: str | None = None
 
                 # 1. Does the parent already live in a group?
                 if parent_id and parent_id in self._span_to_group:
@@ -366,7 +367,10 @@ class _TraceStore:
 
                 # 2. Is this span already known as a parent of another group?
                 if group_key is None and span_id and span_id in self._parent_to_group:
-                    group_key = self._parent_to_group.pop(span_id)
+                    orphan_group = self._parent_to_group.pop(span_id)
+                    # A root arriving after its children still owns the
+                    # externally selectable trace ID.
+                    group_key = trace_id if not parent_id else orphan_group
 
                 # 3. Fall back to the wire trace_id.
                 if group_key is None:
@@ -374,12 +378,18 @@ class _TraceStore:
 
                 # Create the group if needed.
                 if group_key not in self._traces:
-                    if len(self._traces) >= self._max_traces:
+                    if (
+                        len(self._traces) >= self._max_traces
+                        and orphan_group not in self._traces
+                    ):
                         self._evict_oldest()
                     self._traces[group_key] = {"trace_id": group_key, "spans": []}
                     self._seen_spans[group_key] = set()
                 else:
                     self._traces.move_to_end(group_key)
+
+                if orphan_group and orphan_group != group_key:
+                    self._merge_groups(orphan_group, group_key)
 
                 # Insert span (deduplicate).
                 seen = self._seen_spans[group_key]

--- a/cli/test/test_trace_cmd.py
+++ b/cli/test/test_trace_cmd.py
@@ -92,6 +92,36 @@ def test_start_trace_server_raises_bind_error(monkeypatch):
     assert "planoai trace listen" in str(excinfo.value)
 
 
+def test_trace_store_keeps_root_trace_id_when_child_arrives_first():
+    store = trace_cmd._TraceStore()
+    root_trace_id = "a" * 32
+    child_trace_id = "b" * 32
+    root_span_id = "1" * 16
+
+    store.merge_spans(
+        child_trace_id,
+        [
+            {
+                "traceId": child_trace_id,
+                "spanId": "2" * 16,
+                "parentSpanId": root_span_id,
+            }
+        ],
+    )
+    store.merge_spans(
+        root_trace_id,
+        [
+            {
+                "traceId": root_trace_id,
+                "spanId": root_span_id,
+                "parentSpanId": "",
+            }
+        ],
+    )
+
+    assert store.snapshot()[0]["trace_id"] == root_trace_id
+
+
 def test_trace_listen_starts_listener_with_defaults(runner, monkeypatch):
     seen = {}
 


### PR DESCRIPTION
## Summary

Preserve the root span's trace ID as the selectable ID for a logical trace when
an OTLP child span reaches the local listener first.

## Problem

The trace store groups connected spans across wire trace IDs by following
`parentSpanId`. With root-first delivery, the logical group is exposed under the
root's trace ID. With the same connected spans delivered child-first, the root
joins the child's provisional group and the group keeps the child's trace ID.

Because exact-ID lookup uses the group ID, `planoai trace <root-trace-id>` then
prints `No traces found.` even though the group contains both spans.

Child-first is the ordinary order, not an unusual one: the OpenTelemetry SDK
queues spans as they end, so a root ends after its children and is last in the
batch. `Export()` merges span by span, so one normal export request is enough.

This bites when the root and the child carry different wire trace IDs — which is
the case `_TraceStore` exists to handle. Its own docstring says spans "may
arrive with **different** `traceId` values but are linked via `parentSpanId`",
and the cross-trace-ID grouping in `merge_spans` is written for exactly that.
One way a leg picks up an ID the caller does not know:
`extract_or_generate_traceparent` mints a fresh trace ID when a request arrives
without a `traceparent` header (`crates/brightstaff/src/handlers/mod.rs:50`).
When the IDs do match, step 3's fallback keys the group identically and arrival
order does not matter.

The root's ID is also the one a caller already holds: a caller that sends
`traceparent` knows the root ID even when an inner leg ends up on a different
one. Independently of which ID is preferred, the same spans should not resolve
differently based on export order.

## Change

- Re-key a provisional child-created group under the root span's trace ID when
  the root arrives.
- Merge the provisional spans without changing existing grouping or
  deduplication behavior.
- Skip eviction while the group is momentarily reachable under two keys, so the
  merge cannot drop it. The group count is unchanged once the merge completes.
- Add a regression covering child-first delivery.

No CLI, schema, dependency, or persistence change.

## Test plan

- `cd cli && uv run pytest test/test_trace_cmd.py` — 29 passed
- `cd cli && uv run pytest` — 110 passed
- `black 26.3.1` — both changed files left unchanged
- Confirmed the new regression fails on unpatched `main` and passes with this
  change.

AI assistance was used to investigate the behavior and prepare this change.
