### PR TITLE
fix: reconnect Redis session cache

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -248,6 +248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,8 +2762,10 @@ checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itertools 0.13.0",
  "itoa",

--- a/crates/brightstaff/Cargo.toml
+++ b/crates/brightstaff/Cargo.toml
@@ -43,7 +43,7 @@ lru = "0.12"
 metrics = "0.23"
 metrics-exporter-prometheus = { version = "0.15", default-features = false, features = ["http-listener"] }
 metrics-process = "2.1"
-redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "tls-rustls-webpki-roots"] }
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "tls-rustls-webpki-roots", "connection-manager"] }
 reqwest = { version = "0.12.15", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/crates/brightstaff/src/metrics/labels.rs
+++ b/crates/brightstaff/src/metrics/labels.rs
@@ -40,6 +40,13 @@ pub const ROUTING_SVC_POLICY_ERROR: &str = "policy_error";
 pub const SESSION_CACHE_HIT: &str = "hit";
 pub const SESSION_CACHE_MISS: &str = "miss";
 pub const SESSION_CACHE_STORE: &str = "store";
+/// Lookup failed in the backend. Kept apart from `miss` so an unreachable cache is never
+/// read as "cold session" — that looks identical to healthy traffic while stickiness is
+/// entirely off.
+pub const SESSION_CACHE_ERROR: &str = "error";
+/// Store failed in the backend: the binding was not persisted, so the next turn of this
+/// session cannot pin.
+pub const SESSION_CACHE_STORE_ERROR: &str = "store_error";
 
 // Prompt cache outcome values (brightstaff_prompt_cache_requests_total).
 pub const PROMPT_CACHE_HIT: &str = "hit";

--- a/crates/brightstaff/src/metrics/mod.rs
+++ b/crates/brightstaff/src/metrics/mod.rs
@@ -173,7 +173,9 @@ fn describe_all() {
     );
     describe_counter!(
         "brightstaff_session_cache_events_total",
-        "Session affinity cache lookups and stores, by outcome."
+        "Session affinity cache lookups and stores, by outcome: hit, miss, store, error \
+         (lookup failed), store_error (binding not persisted). A rising store with no hit \
+         means bindings are not surviving between turns."
     );
     describe_counter!(
         "brightstaff_prompt_cache_requests_total",

--- a/crates/brightstaff/src/router/orchestrator.rs
+++ b/crates/brightstaff/src/router/orchestrator.rs
@@ -9,7 +9,7 @@ use hyper::header;
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::http::{self, post_and_extract_content};
 use super::model_metrics::ModelMetricsService;
@@ -166,12 +166,28 @@ impl OrchestratorService {
         tenant_id: Option<&str>,
     ) -> Option<SessionBinding> {
         let cache = self.session_cache.as_ref()?;
-        let result = cache.get(&Self::session_key(tenant_id, session_id)).await;
-        bs_metrics::record_session_cache_event(match result {
-            Some(_) => metric_labels::SESSION_CACHE_HIT,
-            None => metric_labels::SESSION_CACHE_MISS,
-        });
-        result
+        match cache.get(&Self::session_key(tenant_id, session_id)).await {
+            Ok(Some(binding)) => {
+                bs_metrics::record_session_cache_event(metric_labels::SESSION_CACHE_HIT);
+                Some(binding)
+            }
+            Ok(None) => {
+                bs_metrics::record_session_cache_event(metric_labels::SESSION_CACHE_MISS);
+                None
+            }
+            // Fail open: route this turn without stickiness rather than reject it, but
+            // count and log it so a degraded cache is visible instead of looking like an
+            // endless run of cold sessions.
+            Err(err) => {
+                bs_metrics::record_session_cache_event(metric_labels::SESSION_CACHE_ERROR);
+                warn!(
+                    session_id = %session_id,
+                    error = %err,
+                    "session cache lookup failed; routing without affinity"
+                );
+                None
+            }
+        }
     }
 
     /// The GC bound for a session binding: the per-scope override when provided,
@@ -193,14 +209,28 @@ impl OrchestratorService {
         gc_ttl: Option<Duration>,
     ) {
         if let Some(ref cache) = self.session_cache {
-            cache
+            let result = cache
                 .put(
                     &Self::session_key(tenant_id, session_id),
                     binding,
                     gc_ttl.unwrap_or(self.session_ttl),
                 )
                 .await;
-            bs_metrics::record_session_cache_event(metric_labels::SESSION_CACHE_STORE);
+            match result {
+                Ok(()) => {
+                    bs_metrics::record_session_cache_event(metric_labels::SESSION_CACHE_STORE);
+                }
+                Err(err) => {
+                    bs_metrics::record_session_cache_event(
+                        metric_labels::SESSION_CACHE_STORE_ERROR,
+                    );
+                    warn!(
+                        session_id = %session_id,
+                        error = %err,
+                        "session cache store failed; next turn cannot pin"
+                    );
+                }
+            }
         }
     }
 
@@ -430,9 +460,16 @@ impl OrchestratorService {
 mod tests {
     use super::*;
     use crate::session_cache::memory::MemorySessionCache;
+    use crate::session_cache::SessionCacheError;
 
     fn make_orchestrator_service(ttl_seconds: u64, max_entries: usize) -> OrchestratorService {
-        let session_cache = Arc::new(MemorySessionCache::new(max_entries));
+        make_service_with_cache(ttl_seconds, Arc::new(MemorySessionCache::new(max_entries)))
+    }
+
+    fn make_service_with_cache(
+        ttl_seconds: u64,
+        session_cache: Arc<dyn SessionCache>,
+    ) -> OrchestratorService {
         OrchestratorService::with_routing(
             "http://localhost:12001/v1/chat/completions".to_string(),
             "Plano-Orchestrator".to_string(),
@@ -462,10 +499,46 @@ mod tests {
         }
     }
 
+    /// Stands in for an unreachable Redis: every operation fails.
+    struct FailingSessionCache;
+
+    #[async_trait::async_trait]
+    impl SessionCache for FailingSessionCache {
+        async fn get(
+            &self,
+            _key: &str,
+        ) -> std::result::Result<Option<SessionBinding>, SessionCacheError> {
+            Err(SessionCacheError::new("unreachable"))
+        }
+
+        async fn put(
+            &self,
+            _key: &str,
+            _binding: SessionBinding,
+            _ttl: Duration,
+        ) -> std::result::Result<(), SessionCacheError> {
+            Err(SessionCacheError::new("unreachable"))
+        }
+
+        async fn remove(&self, _key: &str) -> std::result::Result<(), SessionCacheError> {
+            Err(SessionCacheError::new("unreachable"))
+        }
+    }
+
     #[tokio::test]
     async fn test_cache_miss_returns_none() {
         let svc = make_orchestrator_service(600, 100);
         assert!(svc.get_binding("unknown-session", None).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_failing_cache_fails_open() {
+        let svc = make_service_with_cache(600, Arc::new(FailingSessionCache));
+        // A dead backend must not fail the turn, and must not surface a binding: the
+        // router would otherwise report a session as pinned against a cache that lost it.
+        svc.store_binding("s1", None, binding("gpt-4o", None), None)
+            .await;
+        assert!(svc.get_binding("s1", None).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/brightstaff/src/session_cache/memory.rs
+++ b/crates/brightstaff/src/session_cache/memory.rs
@@ -9,7 +9,7 @@ use lru::LruCache;
 use tokio::sync::Mutex;
 use tracing::info;
 
-use super::{SessionBinding, SessionCache};
+use super::{SessionBinding, SessionCache, SessionCacheError};
 
 type CacheStore = Mutex<LruCache<String, (SessionBinding, Instant, Duration)>>;
 
@@ -61,24 +61,31 @@ impl MemorySessionCache {
 
 #[async_trait]
 impl SessionCache for MemorySessionCache {
-    async fn get(&self, key: &str) -> Option<SessionBinding> {
+    async fn get(&self, key: &str) -> Result<Option<SessionBinding>, SessionCacheError> {
         let mut cache = self.store.lock().await;
         if let Some((binding, inserted_at, ttl)) = cache.get(key) {
             if inserted_at.elapsed() < *ttl {
-                return Some(binding.clone());
+                return Ok(Some(binding.clone()));
             }
         }
-        None
+        Ok(None)
     }
 
-    async fn put(&self, key: &str, binding: SessionBinding, ttl: Duration) {
+    async fn put(
+        &self,
+        key: &str,
+        binding: SessionBinding,
+        ttl: Duration,
+    ) -> Result<(), SessionCacheError> {
         self.store
             .lock()
             .await
             .put(key.to_string(), (binding, Instant::now(), ttl));
+        Ok(())
     }
 
-    async fn remove(&self, key: &str) {
+    async fn remove(&self, key: &str) -> Result<(), SessionCacheError> {
         self.store.lock().await.pop(key);
+        Ok(())
     }
 }

--- a/crates/brightstaff/src/session_cache/mod.rs
+++ b/crates/brightstaff/src/session_cache/mod.rs
@@ -146,19 +146,44 @@ mod epoch_secs {
     }
 }
 
+/// A backend failure from the session cache, reported separately from "nothing stored"
+/// so callers can tell a cold session apart from an unreachable cache.
+#[derive(Debug)]
+pub struct SessionCacheError(String);
+
+impl SessionCacheError {
+    pub fn new(err: impl std::fmt::Display) -> Self {
+        Self(err.to_string())
+    }
+}
+
+impl std::fmt::Display for SessionCacheError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SessionCacheError {}
+
 #[async_trait]
 pub trait SessionCache: Send + Sync {
-    /// Look up a session binding by key. `None` when absent or GC-evicted. Warmth is
-    /// the caller's concern (time since `last_used`), not the cache's.
-    async fn get(&self, key: &str) -> Option<SessionBinding>;
+    /// Look up a session binding by key. `Ok(None)` when absent or GC-evicted, `Err` when
+    /// the backend itself failed. Warmth is the caller's concern (time since `last_used`),
+    /// not the cache's.
+    async fn get(&self, key: &str) -> Result<Option<SessionBinding>, SessionCacheError>;
 
     /// Store a session binding with the given GC TTL. The TTL is only a memory bound
     /// (keep the entry around at least as long as it could plausibly be warm); it does
     /// not define warmth.
-    async fn put(&self, key: &str, binding: SessionBinding, ttl: Duration);
+    async fn put(
+        &self,
+        key: &str,
+        binding: SessionBinding,
+        ttl: Duration,
+    ) -> Result<(), SessionCacheError>;
 
     /// Remove a session binding by key.
-    async fn remove(&self, key: &str);
+    async fn remove(&self, key: &str) -> Result<(), SessionCacheError>;
 }
 
 /// Initialize the session cache backend from config.

--- a/crates/brightstaff/src/session_cache/redis.rs
+++ b/crates/brightstaff/src/session_cache/redis.rs
@@ -1,21 +1,32 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use redis::aio::MultiplexedConnection;
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::AsyncCommands;
 
-use super::{SessionBinding, SessionCache};
+use super::{SessionBinding, SessionCache, SessionCacheError};
 
 const KEY_PREFIX: &str = "plano:affinity:";
 
+/// Session affinity is an optimization, so a slow backend must never hold up a routing
+/// decision. Reconnects happen in the background between these attempts.
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+
 pub struct RedisSessionCache {
-    conn: MultiplexedConnection,
+    /// A `ConnectionManager` rather than a bare `MultiplexedConnection`: the latter never
+    /// reconnects, so one dropped socket (idle timeout, failover, network blip) disables
+    /// session affinity for the rest of the process's lifetime.
+    conn: ConnectionManager,
 }
 
 impl RedisSessionCache {
     pub async fn new(url: &str) -> Result<Self, redis::RedisError> {
         let client = redis::Client::open(url)?;
-        let conn = client.get_multiplexed_async_connection().await?;
+        let config = ConnectionManagerConfig::new()
+            .set_connection_timeout(CONNECTION_TIMEOUT)
+            .set_response_timeout(RESPONSE_TIMEOUT);
+        let conn = ConnectionManager::new_with_config(client, config).await?;
         Ok(Self { conn })
     }
 
@@ -26,25 +37,111 @@ impl RedisSessionCache {
 
 #[async_trait]
 impl SessionCache for RedisSessionCache {
-    async fn get(&self, key: &str) -> Option<SessionBinding> {
+    async fn get(&self, key: &str) -> Result<Option<SessionBinding>, SessionCacheError> {
         let mut conn = self.conn.clone();
-        let value: Option<String> = conn.get(Self::make_key(key)).await.ok()?;
-        value.and_then(|v| serde_json::from_str(&v).ok())
+        let value: Option<String> = conn
+            .get(Self::make_key(key))
+            .await
+            .map_err(SessionCacheError::new)?;
+        // A binding written by an incompatible build is unusable but is not a backend
+        // failure: treat it as absent and let the session re-bind.
+        Ok(value.and_then(|v| serde_json::from_str(&v).ok()))
     }
 
-    async fn put(&self, key: &str, binding: SessionBinding, ttl: Duration) {
+    async fn put(
+        &self,
+        key: &str,
+        binding: SessionBinding,
+        ttl: Duration,
+    ) -> Result<(), SessionCacheError> {
         let mut conn = self.conn.clone();
         // The Redis TTL is only a GC bound; warmth is decided by the router from
         // `binding.last_used`, not by expiry here.
         let ttl_secs = ttl.as_secs().max(1);
-        let Ok(json) = serde_json::to_string(&binding) else {
-            return;
-        };
-        let _: Result<(), _> = conn.set_ex(Self::make_key(key), json, ttl_secs).await;
+        let json = serde_json::to_string(&binding).map_err(SessionCacheError::new)?;
+        conn.set_ex::<_, _, ()>(Self::make_key(key), json, ttl_secs)
+            .await
+            .map_err(SessionCacheError::new)
     }
 
-    async fn remove(&self, key: &str) {
+    async fn remove(&self, key: &str) -> Result<(), SessionCacheError> {
         let mut conn = self.conn.clone();
-        let _: Result<(), _> = conn.del(Self::make_key(key)).await;
+        conn.del::<_, ()>(Self::make_key(key))
+            .await
+            .map_err(SessionCacheError::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding() -> SessionBinding {
+        SessionBinding {
+            anchor_model: "gpt-4o".to_string(),
+            default_model: "gpt-4o".to_string(),
+            route_name: None,
+            prefix_hash: None,
+            last_used: std::time::SystemTime::now(),
+            cached_tokens: 0,
+            baseline_usd: 0.0,
+            switch_spend_usd: 0.0,
+            switches: 0,
+            session_cost_usd: 0.0,
+            history: Vec::new(),
+        }
+    }
+
+    /// A non-reconnecting connection turned one dropped socket into permanently disabled
+    /// affinity, and every later lookup was indistinguishable from a cold session.
+    ///
+    /// Needs a disposable Redis:
+    /// `PLANO_TEST_REDIS_URL=redis://127.0.0.1:6379 cargo test -p brightstaff \
+    ///  session_cache::redis -- --ignored`
+    #[tokio::test]
+    #[ignore = "requires a Redis at PLANO_TEST_REDIS_URL"]
+    async fn recovers_after_the_server_drops_the_connection() {
+        let url = std::env::var("PLANO_TEST_REDIS_URL").expect("PLANO_TEST_REDIS_URL must be set");
+        let cache = RedisSessionCache::new(&url).await.expect("connect");
+        let key = "reconnect-test";
+
+        cache
+            .put(key, binding(), Duration::from_secs(60))
+            .await
+            .expect("initial put");
+        assert!(cache.get(key).await.expect("initial get").is_some());
+
+        // Drop the cache's connection server-side, standing in for an idle timeout or a
+        // failover. CLIENT KILL skips the caller by default, so this connection survives.
+        let client = redis::Client::open(url.as_str()).expect("client");
+        let mut killer = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("killer connection");
+        let killed: i64 = redis::cmd("CLIENT")
+            .arg("KILL")
+            .arg("TYPE")
+            .arg("normal")
+            .query_async(&mut killer)
+            .await
+            .expect("client kill");
+        assert!(killed > 0, "expected to kill at least the cache connection");
+
+        // Reconnection happens in the background, so the first call after the kill may
+        // still hit the dead socket.
+        let mut last_err = None;
+        for _ in 0..20 {
+            match cache.get(key).await {
+                Ok(found) => {
+                    assert!(found.is_some(), "binding lost across reconnect");
+                    return;
+                }
+                Err(err) => {
+                    last_err = Some(err.to_string());
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            }
+        }
+        panic!("cache never recovered after connection drop: {last_err:?}");
     }
 }


### PR DESCRIPTION
Keep prompt-cache affinity working after Valkey idle connection timeouts and expose cache backend failures instead of reporting them as misses.

DO Managed Valkey(Redis) has a 5-6 min timeouts based on our testing.  After this patch is deployed, you should no longer need to restart Plano after Valkey idle timeouts.
The ConnectionManager automatically reconnects when Valkey closes the idle connection, so prompt-cache affinity can recover without a pod restart. Backend errors will also appear as error or store_error metrics instead of misleading miss/store counts.
A restart is still required once during rollout so the running pods load the new Plano version. After deployment, no recurring manual restarts should be needed.
