### PR TITLE
Add workflow_dispatch to docker-push-release

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -5,10 +5,16 @@ env:
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/plano
   DOCR_IMAGE: registry.digitalocean.com/genai-prod/plano
   DOCR_PREVIEW_IMAGE: registry.digitalocean.com/genai-preview/plano
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. 0.4.32)"
+        required: true
 
 permissions:
   contents: read
@@ -21,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -49,7 +57,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value={{tag}}
+            type=raw,value=${{ env.RELEASE_TAG }}
 
       - name: Build and Push ARM64 Image
         uses: docker/build-push-action@v6
@@ -60,8 +68,8 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}-arm64
-            ${{ env.GHCR_IMAGE }}:${{ github.event.release.tag_name }}-arm64
-            ${{ env.DOCR_IMAGE }}:${{ github.event.release.tag_name }}-arm64
+            ${{ env.GHCR_IMAGE }}:${{ env.RELEASE_TAG }}-arm64
+            ${{ env.DOCR_IMAGE }}:${{ env.RELEASE_TAG }}-arm64
 
       - name: Switch to DOCR preview
         uses: digitalocean/action-doctl@v2
@@ -74,7 +82,7 @@ jobs:
       - name: Push to DOCR Preview
         run: |
           docker buildx imagetools create \
-            -t ${{ env.DOCR_PREVIEW_IMAGE }}:${{ github.event.release.tag_name }}-arm64 \
+            -t ${{ env.DOCR_PREVIEW_IMAGE }}:${{ env.RELEASE_TAG }}-arm64 \
             ${{ steps.meta.outputs.tags }}-arm64
 
   # Build AMD64 image on GitHub's AMD64 runner — push to both registries
@@ -83,6 +91,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -111,7 +121,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value={{tag}}
+            type=raw,value=${{ env.RELEASE_TAG }}
 
       - name: Build and Push AMD64 Image
         uses: docker/build-push-action@v6
@@ -122,8 +132,8 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}-amd64
-            ${{ env.GHCR_IMAGE }}:${{ github.event.release.tag_name }}-amd64
-            ${{ env.DOCR_IMAGE }}:${{ github.event.release.tag_name }}-amd64
+            ${{ env.GHCR_IMAGE }}:${{ env.RELEASE_TAG }}-amd64
+            ${{ env.DOCR_IMAGE }}:${{ env.RELEASE_TAG }}-amd64
 
       - name: Switch to DOCR preview
         uses: digitalocean/action-doctl@v2
@@ -136,7 +146,7 @@ jobs:
       - name: Push to DOCR Preview
         run: |
           docker buildx imagetools create \
-            -t ${{ env.DOCR_PREVIEW_IMAGE }}:${{ github.event.release.tag_name }}-amd64 \
+            -t ${{ env.DOCR_PREVIEW_IMAGE }}:${{ env.RELEASE_TAG }}-amd64 \
             ${{ steps.meta.outputs.tags }}-amd64
 
   # Combine ARM64 and AMD64 images into multi-arch manifests for both registries
@@ -171,7 +181,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value={{tag}}
+            type=raw,value=${{ env.RELEASE_TAG }}
 
       - name: Create Docker Hub Multi-Arch Manifest
         run: |
@@ -182,7 +192,7 @@ jobs:
 
       - name: Create GHCR Multi-Arch Manifest
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG=${{ env.RELEASE_TAG }}
           docker buildx imagetools create \
             -t ${{ env.GHCR_IMAGE }}:${TAG} \
             ${{ env.GHCR_IMAGE }}:${TAG}-arm64 \
@@ -190,7 +200,7 @@ jobs:
 
       - name: Create DOCR Prod Multi-Arch Manifest
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG=${{ env.RELEASE_TAG }}
           docker buildx imagetools create \
             -t ${{ env.DOCR_IMAGE }}:${TAG} \
             ${{ env.DOCR_IMAGE }}:${TAG}-arm64 \
@@ -206,7 +216,7 @@ jobs:
 
       - name: Create DOCR Preview Multi-Arch Manifest
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG=${{ env.RELEASE_TAG }}
           docker buildx imagetools create \
             -t ${{ env.DOCR_PREVIEW_IMAGE }}:${TAG} \
             ${{ steps.meta.outputs.tags }}-arm64 \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds manual trigger support to **Publish docker image (release)** so release Docker images can be built when GitHub Actions release automation did not run (e.g. during an outage).

Changes:
- `workflow_dispatch` with required `tag` input (same pattern as `publish-binaries.yml`)
- `RELEASE_TAG` env (`github.event.release.tag_name || inputs.tag`) used for checkout ref and image tags
- Metadata action uses explicit release tag instead of `{{tag}}` so dispatch works without a `release` event

After merge: Actions → **Publish docker image (release)** → **Run workflow** → enter the release tag (e.g. `0.4.32`).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://digitalocean.slack.com/archives/C0AMWRZ9YD8/p1786054869249119?thread_ts=1786054869.249119&cid=C0AMWRZ9YD8)

<div><a href="https://cursor.com/agents/bc-271fad49-dfd7-5eb6-b48d-9c1848b832f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-271fad49-dfd7-5eb6-b48d-9c1848b832f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

