### PR TITLE
Opt-in: skip re-routing on non-user turns

### DIFF
--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -594,6 +594,12 @@ properties:
               Useful for evals/benchmarks. Default false.
         required: ["max_switch_spend_pct"]
         additionalProperties: false
+      route_on_user_turn:
+        type: boolean
+        description: >
+          Opt-in: run the quality router only when the last message is a user turn.
+          Tool results, assistant continuations, and other non-user tails replay the
+          prior routing decision instead of re-selecting a model. Default false.
     additionalProperties: false
   state_storage:
     type: object

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -594,7 +594,7 @@ properties:
               Useful for evals/benchmarks. Default false.
         required: ["max_switch_spend_pct"]
         additionalProperties: false
-      route_on_user_turn:
+      auto_pin_tool_calls:
         type: boolean
         description: >
           Opt-in: run the quality router only when the last message is a user turn.

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -594,7 +594,7 @@ properties:
               Useful for evals/benchmarks. Default false.
         required: ["max_switch_spend_pct"]
         additionalProperties: false
-      auto_pin_tool_calls:
+      route_on_user_only:
         type: boolean
         description: >
           Opt-in: run the quality router only when the last message is a user turn.

--- a/crates/brightstaff/src/app_state.rs
+++ b/crates/brightstaff/src/app_state.rs
@@ -41,6 +41,6 @@ pub struct AppState {
     /// Independent of prompt caching; `None` when not configured (off by default).
     pub routing_budget: Option<EffectiveRoutingBudget>,
     /// When true, the quality router runs only on a trailing user message.
-    /// Resolved from `routing.auto_pin_tool_calls`. Off by default.
-    pub auto_pin_tool_calls: bool,
+    /// Resolved from `routing.route_on_user_only`. Off by default.
+    pub route_on_user_only: bool,
 }

--- a/crates/brightstaff/src/app_state.rs
+++ b/crates/brightstaff/src/app_state.rs
@@ -41,6 +41,6 @@ pub struct AppState {
     /// Independent of prompt caching; `None` when not configured (off by default).
     pub routing_budget: Option<EffectiveRoutingBudget>,
     /// When true, the quality router runs only on a trailing user message.
-    /// Resolved from `routing.route_on_user_turn`. Off by default.
-    pub route_on_user_turn: bool,
+    /// Resolved from `routing.auto_pin_tool_calls`. Off by default.
+    pub auto_pin_tool_calls: bool,
 }

--- a/crates/brightstaff/src/app_state.rs
+++ b/crates/brightstaff/src/app_state.rs
@@ -40,4 +40,7 @@ pub struct AppState {
     /// Per-session model-switch cost gate, resolved from `routing.routing_budget`.
     /// Independent of prompt caching; `None` when not configured (off by default).
     pub routing_budget: Option<EffectiveRoutingBudget>,
+    /// When true, the quality router runs only on a trailing user message.
+    /// Resolved from `routing.route_on_user_turn`. Off by default.
+    pub route_on_user_turn: bool,
 }

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -30,6 +30,7 @@ use crate::handlers::agents::pipeline::PipelineProcessor;
 use crate::handlers::extract_request_id;
 use crate::handlers::full;
 use crate::metrics as bs_metrics;
+use crate::metrics::labels as metric_labels;
 use crate::state::response_state_processor::ResponsesStateProcessor;
 use crate::state::{
     extract_input_items, retrieve_and_combine_input, StateStorage, StateStorageError,
@@ -312,7 +313,13 @@ async fn llm_chat_inner(
     let routing_budget = state.routing_budget;
     // Derive the implicit session key when either prompt-caching affinity or the
     // routing budget is active — the budget needs a session anchor even with caching off.
-    let implicit_affinity_enabled = prompt_caching.session_affinity || routing_budget.is_some();
+    // Routing preferences need one too: they let the router dispatch somewhere other than
+    // the model the client named, and the rest of an agentic tool loop has to be able to
+    // replay that choice (see `session_router::reuse_for_tool_loop`).
+    let routing_can_override_model = inline_routing_preferences.is_some()
+        || state.orchestrator_service.has_routing_preferences();
+    let implicit_affinity_enabled =
+        prompt_caching.session_affinity || routing_budget.is_some() || routing_can_override_model;
     let request_messages = client_request.get_messages();
     let session_router::SessionResolution {
         request_prefix_hash,
@@ -359,44 +366,79 @@ async fn llm_chat_inner(
     // --- Phase 3: Route the request (quality), then apply the session-cache decision ---
     // Routing stays cache-blind: the quality router always picks a candidate. The
     // session router then honors it or sticks to the warm anchor (see `session_router`).
-    let routing_span = info_span!(
-        "routing",
-        component = "routing",
-        http.method = "POST",
-        http.target = %request_path,
-        model.requested = %model_from_request,
-        model.alias_resolved = %alias_resolved_model,
-        route.selected_model = tracing::field::Empty,
-        routing.determination_ms = tracing::field::Empty,
-    );
-    let routing_result = match async {
-        set_service_name(operation_component::ROUTING);
-        router_chat_get_upstream_model(
-            Arc::clone(&state.orchestrator_service),
-            client_request,
-            &request_path,
-            &request_id,
-            inline_routing_preferences,
+    //
+    // A step of an agentic tool loop skips the router entirely and replays the model the
+    // loop is already running on, so a single user turn can't drift across models
+    // mid-generation. Fresh user turns always route.
+    let loop_reuse = if session_router::is_tool_loop_continuation(&request_messages) {
+        session_router::reuse_for_tool_loop(
+            &state.orchestrator_service,
+            session_id.as_deref(),
+            tenant_id.as_deref(),
+            request_prefix_hash,
+            &alias_resolved_model,
         )
         .await
-    }
-    .instrument(routing_span)
-    .await
-    {
-        Ok(result) => result,
-        Err(err) => {
-            let mut internal_error = Response::new(full(err.message));
-            *internal_error.status_mut() = err.status_code;
-            return Ok(internal_error);
-        }
+    } else {
+        None
     };
 
-    let candidate_model = if routing_result.model_name != "none" {
-        routing_result.model_name
-    } else {
-        alias_resolved_model.clone()
+    let (candidate_model, candidate_route) = match loop_reuse {
+        Some(reuse) => {
+            debug!(
+                model = %reuse.model,
+                "tool-loop continuation — replaying this loop's model instead of re-routing"
+            );
+            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_TOOL_LOOP);
+            get_active_span(|span| {
+                span.set_attribute(opentelemetry::KeyValue::new(
+                    tracing_plano::ROUTING_SKIPPED,
+                    metric_labels::ROUTING_SKIP_TOOL_LOOP,
+                ));
+            });
+            (reuse.model, reuse.route_name)
+        }
+        None => {
+            let routing_span = info_span!(
+                "routing",
+                component = "routing",
+                http.method = "POST",
+                http.target = %request_path,
+                model.requested = %model_from_request,
+                model.alias_resolved = %alias_resolved_model,
+                route.selected_model = tracing::field::Empty,
+                routing.determination_ms = tracing::field::Empty,
+            );
+            let routing_result = match async {
+                set_service_name(operation_component::ROUTING);
+                router_chat_get_upstream_model(
+                    Arc::clone(&state.orchestrator_service),
+                    client_request,
+                    &request_path,
+                    &request_id,
+                    inline_routing_preferences,
+                )
+                .await
+            }
+            .instrument(routing_span)
+            .await
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    let mut internal_error = Response::new(full(err.message));
+                    *internal_error.status_mut() = err.status_code;
+                    return Ok(internal_error);
+                }
+            };
+
+            let candidate_model = if routing_result.model_name != "none" {
+                routing_result.model_name
+            } else {
+                alias_resolved_model.clone()
+            };
+            (candidate_model, routing_result.route_name)
+        }
     };
-    let candidate_route = routing_result.route_name;
 
     let decision = session_router::route(
         &state.orchestrator_service,
@@ -408,6 +450,7 @@ async fn llm_chat_inner(
             context_tokens,
             candidate_model: &candidate_model,
             candidate_route: candidate_route.as_deref(),
+            requested_model: &alias_resolved_model,
         },
     )
     .await;
@@ -468,6 +511,7 @@ async fn llm_chat_inner(
             tenant_id: tenant_id.clone(),
             anchor_model: resolved_model.clone(),
             default_model: decision.default_model.clone(),
+            requested_model: decision.requested_model.clone(),
             route_name: resolved_route_name.clone(),
             prefix_hash: request_prefix_hash,
             baseline_usd: decision.baseline_usd,

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -322,7 +322,7 @@ async fn llm_chat_inner(
         || state.orchestrator_service.has_routing_preferences();
     let implicit_affinity_enabled = prompt_caching.session_affinity
         || routing_budget.is_some()
-        || (state.auto_pin_tool_calls && routing_can_override_model);
+        || (state.route_on_user_only && routing_can_override_model);
     let request_messages = client_request.get_messages();
     let session_router::SessionResolution {
         request_prefix_hash,
@@ -370,23 +370,22 @@ async fn llm_chat_inner(
     // Routing stays cache-blind: the quality router always picks a candidate. The
     // session router then honors it or sticks to the warm anchor (see `session_router`).
     //
-    // Opt-in (`routing.auto_pin_tool_calls`): routing runs only on a trailing user
+    // Opt-in (`routing.route_on_user_only`): routing runs only on a trailing user
     // message. Tool results and other non-user tails replay the prior decision.
-    let loop_reuse = if session_router::should_reuse_prior_decision(
-        state.auto_pin_tool_calls,
-        &request_messages,
-    ) {
-        session_router::reuse_prior_decision(
-            &state.orchestrator_service,
-            session_id.as_deref(),
-            tenant_id.as_deref(),
-            request_prefix_hash,
-            &alias_resolved_model,
-        )
-        .await
-    } else {
-        None
-    };
+    let loop_reuse =
+        if session_router::should_reuse_prior_decision(state.route_on_user_only, &request_messages)
+        {
+            session_router::reuse_prior_decision(
+                &state.orchestrator_service,
+                session_id.as_deref(),
+                tenant_id.as_deref(),
+                request_prefix_hash,
+                &alias_resolved_model,
+            )
+            .await
+        } else {
+            None
+        };
 
     let (candidate_model, candidate_route) = match loop_reuse {
         Some(reuse) => {

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -322,7 +322,7 @@ async fn llm_chat_inner(
         || state.orchestrator_service.has_routing_preferences();
     let implicit_affinity_enabled = prompt_caching.session_affinity
         || routing_budget.is_some()
-        || (state.route_on_user_turn && routing_can_override_model);
+        || (state.auto_pin_tool_calls && routing_can_override_model);
     let request_messages = client_request.get_messages();
     let session_router::SessionResolution {
         request_prefix_hash,
@@ -370,22 +370,23 @@ async fn llm_chat_inner(
     // Routing stays cache-blind: the quality router always picks a candidate. The
     // session router then honors it or sticks to the warm anchor (see `session_router`).
     //
-    // Opt-in (`routing.route_on_user_turn`): routing runs only on a trailing user
+    // Opt-in (`routing.auto_pin_tool_calls`): routing runs only on a trailing user
     // message. Tool results and other non-user tails replay the prior decision.
-    let loop_reuse =
-        if session_router::should_reuse_prior_decision(state.route_on_user_turn, &request_messages)
-        {
-            session_router::reuse_prior_decision(
-                &state.orchestrator_service,
-                session_id.as_deref(),
-                tenant_id.as_deref(),
-                request_prefix_hash,
-                &alias_resolved_model,
-            )
-            .await
-        } else {
-            None
-        };
+    let loop_reuse = if session_router::should_reuse_prior_decision(
+        state.auto_pin_tool_calls,
+        &request_messages,
+    ) {
+        session_router::reuse_prior_decision(
+            &state.orchestrator_service,
+            session_id.as_deref(),
+            tenant_id.as_deref(),
+            request_prefix_hash,
+            &alias_resolved_model,
+        )
+        .await
+    } else {
+        None
+    };
 
     let (candidate_model, candidate_route) = match loop_reuse {
         Some(reuse) => {

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -316,12 +316,13 @@ async fn llm_chat_inner(
     // Derive the implicit session key when either prompt-caching affinity or the
     // routing budget is active — the budget needs a session anchor even with caching off.
     // Routing preferences need one too: they let the router dispatch somewhere other than
-    // the model the client named, and the rest of an agentic tool loop has to be able to
-    // replay that choice (see `session_router::reuse_for_tool_loop`).
+    // the model the client named, and later non-user turns have to be able to replay
+    // that choice (see `session_router::reuse_prior_decision`).
     let routing_can_override_model = inline_routing_preferences.is_some()
         || state.orchestrator_service.has_routing_preferences();
-    let implicit_affinity_enabled =
-        prompt_caching.session_affinity || routing_budget.is_some() || routing_can_override_model;
+    let implicit_affinity_enabled = prompt_caching.session_affinity
+        || routing_budget.is_some()
+        || (state.route_on_user_turn && routing_can_override_model);
     let request_messages = client_request.get_messages();
     let session_router::SessionResolution {
         request_prefix_hash,
@@ -369,33 +370,34 @@ async fn llm_chat_inner(
     // Routing stays cache-blind: the quality router always picks a candidate. The
     // session router then honors it or sticks to the warm anchor (see `session_router`).
     //
-    // A step of an agentic tool loop skips the router entirely and replays the model the
-    // loop is already running on, so a single user turn can't drift across models
-    // mid-generation. Fresh user turns always route.
-    let loop_reuse = if session_router::is_tool_loop_continuation(&request_messages) {
-        session_router::reuse_for_tool_loop(
-            &state.orchestrator_service,
-            session_id.as_deref(),
-            tenant_id.as_deref(),
-            request_prefix_hash,
-            &alias_resolved_model,
-        )
-        .await
-    } else {
-        None
-    };
+    // Opt-in (`routing.route_on_user_turn`): routing runs only on a trailing user
+    // message. Tool results and other non-user tails replay the prior decision.
+    let loop_reuse =
+        if session_router::should_reuse_prior_decision(state.route_on_user_turn, &request_messages)
+        {
+            session_router::reuse_prior_decision(
+                &state.orchestrator_service,
+                session_id.as_deref(),
+                tenant_id.as_deref(),
+                request_prefix_hash,
+                &alias_resolved_model,
+            )
+            .await
+        } else {
+            None
+        };
 
     let (candidate_model, candidate_route) = match loop_reuse {
         Some(reuse) => {
             debug!(
                 model = %reuse.model,
-                "tool-loop continuation — replaying this loop's model instead of re-routing"
+                "not a user turn — replaying the prior model instead of re-routing"
             );
-            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_TOOL_LOOP);
+            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_NOT_USER_TURN);
             get_active_span(|span| {
                 span.set_attribute(opentelemetry::KeyValue::new(
                     tracing_plano::ROUTING_SKIPPED,
-                    metric_labels::ROUTING_SKIP_TOOL_LOOP,
+                    metric_labels::ROUTING_SKIP_NOT_USER_TURN,
                 ));
             });
             (reuse.model, reuse.route_name)

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -1034,7 +1034,7 @@ async fn send_upstream(
 
 /// Resolves model aliases by looking up the requested model in the model_aliases map.
 /// Returns the target model if an alias is found, otherwise returns the original model.
-fn resolve_model_alias(
+pub(crate) fn resolve_model_alias(
     model_from_request: &str,
     model_aliases: &Option<HashMap<String, ModelAlias>>,
 ) -> String {

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -1282,6 +1282,26 @@ mod tests {
         assert!(!is_user_turn(&msgs));
     }
 
+    /// Codex registers custom tools by default, so most of its continuations carry
+    /// `custom_tool_call_output` rather than `function_call_output`.
+    #[test]
+    fn responses_custom_tool_call_output_is_a_continuation() {
+        let msgs = messages_from(
+            "/v1/responses",
+            serde_json::json!({
+                "model": "gpt-5.3-codex",
+                "input": [
+                    {"role": "user", "content": "run the tests"},
+                    {"type": "custom_tool_call", "id": "ctc_1", "call_id": "call_1",
+                     "name": "shell", "input": "cargo test", "status": "completed"},
+                    {"type": "custom_tool_call_output", "call_id": "call_1",
+                     "output": "test result: ok"}
+                ]
+            }),
+        );
+        assert!(!is_user_turn(&msgs));
+    }
+
     #[test]
     fn plain_user_turn_routes_and_empty_history_does_not() {
         let msgs = messages_from(
@@ -1516,6 +1536,52 @@ mod tests {
         }
     }
 
+    /// Companion to the OpenAI and Anthropic attachment cases above: a Bedrock image
+    /// with no caption is a real user turn and must open a route.
+    #[test]
+    fn attachment_only_bedrock_user_tail_is_a_user_turn() {
+        use hermesllm::apis::amazon_bedrock::{
+            ContentBlock, ConversationRole, ConverseRequest, ImageBlock, ImageSource,
+            Message as BedrockMessage,
+        };
+
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet".to_string(),
+            messages: Some(vec![
+                BedrockMessage {
+                    role: ConversationRole::User,
+                    content: vec![ContentBlock::Text {
+                        text: "fix the bug".to_string(),
+                    }],
+                },
+                BedrockMessage {
+                    role: ConversationRole::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "Fixed it.".to_string(),
+                    }],
+                },
+                BedrockMessage {
+                    role: ConversationRole::User,
+                    content: vec![ContentBlock::Image {
+                        image: ImageBlock {
+                            source: ImageSource::Base64 {
+                                media_type: "image/png".to_string(),
+                                data: "iVBORw0KGgo=".to_string(),
+                            },
+                        },
+                    }],
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let msgs = ProviderRequestType::BedrockConverse(request).get_messages();
+        assert!(
+            is_user_turn(&msgs),
+            "bedrock pinned an attachment-only turn, normalized to {msgs:?}"
+        );
+    }
+
     /// Claude Code injects reminders and hook output as user-role text. On their own they
     /// are not a new utterance, so the loop stays pinned.
     #[test]
@@ -1643,6 +1709,42 @@ mod tests {
             .expect("an unrouted turn still anchors the loop");
         assert_eq!(reuse.model, CLIENT_MODEL);
         assert!(reuse.route_name.is_none());
+    }
+
+    /// Known limitation of a *shared explicit* `X-Model-Affinity` id: one session key
+    /// holds one binding, so a side call (side chat, summarizer, subagent) overwrites the
+    /// main loop's lane and prefix. The guards keep the side call from being pinned to the
+    /// wrong model, but the loop's pin is evicted rather than kept alongside it, and the
+    /// next continuation re-routes. Implicit affinity does not have this problem: the side
+    /// call's different prompt prefix derives its own key.
+    #[tokio::test]
+    async fn a_side_call_on_a_shared_affinity_id_evicts_the_loop_pin() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 5).await;
+
+        // Side call: same affinity header, different model lane and prompt prefix.
+        route(
+            &orch,
+            None,
+            RouteFacts {
+                session_id: Some("s1"),
+                tenant_id: None,
+                prefix_hash: Some(2),
+                context_tokens: 1_000,
+                candidate_model: "google/cheap",
+                candidate_route: Some("summarize"),
+                requested_model: "anthropic/small-fast",
+            },
+        )
+        .await;
+
+        // The main loop's next continuation can no longer find its decision.
+        assert!(
+            reuse_prior_decision(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+                .await
+                .is_none(),
+            "side call should have overwritten the loop binding"
+        );
     }
 
     /// Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` side calls ride the same prompt prefix

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -1230,9 +1230,10 @@ mod tests {
                 "model": "gpt-5.3-codex",
                 "input": [
                     {"role": "user", "content": "fix the bug in main.rs"},
-                    {"type": "function_call", "call_id": "call_1", "name": "exec_command",
-                     "arguments": "{\"cmd\":\"cat main.rs\"}"},
-                    {"type": "function_call_output", "call_id": "call_1",
+                    {"type": "function_call", "id": "fc_1", "call_id": "call_1",
+                     "name": "exec_command", "arguments": "{\"cmd\":\"cat main.rs\"}",
+                     "status": "completed"},
+                    {"type": "function_call_output", "id": "fc_out_1", "call_id": "call_1",
                      "output": {"stdout": "fn main() {}"}}
                 ]
             }),

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -27,7 +27,8 @@
 use std::time::{Duration, SystemTime};
 
 use common::configuration::EffectiveRoutingBudget;
-use hermesllm::apis::openai::{Message, Role};
+use hermesllm::apis::openai::{ContentPart, Message, MessageContent, Role};
+use hermesllm::transforms::lib::ExtractText;
 use hermesllm::{provider_cache_capability, ProviderCacheCapability, ProviderId};
 use opentelemetry::trace::get_active_span;
 use opentelemetry::KeyValue;
@@ -88,15 +89,64 @@ pub fn resolve_session(
     }
 }
 
+/// Envelopes Claude Code injects as user-role text next to tool results. They are
+/// written by the harness, not spoken by the user, so a tail made up only of these
+/// does not open a new turn.
+const INJECTED_USER_ENVELOPES: [(&str, &str); 2] = [
+    ("<system-reminder>", "</system-reminder>"),
+    ("<user-prompt-submit-hook>", "</user-prompt-submit-hook>"),
+];
+
+/// Remove every [`INJECTED_USER_ENVELOPES`] span, leaving whatever the user actually typed.
+/// An unterminated opening tag swallows the rest of the text — a truncated envelope is
+/// still harness output.
+fn strip_injected_envelopes(text: &str) -> String {
+    let mut remaining = text.to_string();
+
+    for (open, close) in INJECTED_USER_ENVELOPES {
+        while let Some(start) = remaining.find(open) {
+            let body_start = start + open.len();
+            let end = match remaining[body_start..].find(close) {
+                Some(offset) => body_start + offset + close.len(),
+                None => remaining.len(),
+            };
+            remaining.replace_range(start..end, "");
+        }
+    }
+
+    remaining
+}
+
+/// Whether the message carries user-supplied content that is not text — an image today.
+/// A pasted screenshot with no caption is still the user speaking, so it opens a turn
+/// even though there is no text to check.
+fn has_non_text_content(content: &Option<MessageContent>) -> bool {
+    matches!(content, Some(MessageContent::Parts(parts))
+        if parts.iter().any(|part| !matches!(part, ContentPart::Text { .. })))
+}
+
 /// Whether this request is a fresh user turn and should go through the quality router.
 ///
-/// Only the tail is examined. A trailing [`Role::User`] is a new utterance — including
-/// Anthropic packing new user text alongside `tool_result` blocks, which normalizes to
-/// a trailing user message. Anything else (tool results, assistant output, empty
-/// history) is not a user turn; routing is skipped and the prior decision is replayed
-/// when a warm binding exists.
+/// Only the tail is examined. A trailing [`Role::User`] is a new utterance when it
+/// carries an attachment, or text that survives stripping the harness envelopes —
+/// including Anthropic packing new user text alongside `tool_result` blocks, which
+/// normalizes to a trailing user message. Anything else (tool results, assistant
+/// output, an empty or reminder-only user tail, empty history) is not a user turn;
+/// routing is skipped and the prior decision is replayed when a warm binding exists.
 pub fn is_user_turn(messages: &[Message]) -> bool {
-    matches!(messages.last(), Some(m) if m.role == Role::User)
+    let Some(last) = messages.last() else {
+        return false;
+    };
+    if last.role != Role::User {
+        return false;
+    }
+    if has_non_text_content(&last.content) {
+        return true;
+    }
+
+    !strip_injected_envelopes(&last.content.extract_text())
+        .trim()
+        .is_empty()
 }
 
 /// Whether this request should skip the quality router and replay the prior decision.
@@ -1283,6 +1333,251 @@ mod tests {
                 "messages": [
                     {"role": "user", "content": "fix the bug"},
                     {"role": "assistant", "content": "Looking at main.rs"}
+                ]
+            }),
+        );
+        assert!(!is_user_turn(&msgs));
+    }
+
+    /// A user-role message with nothing in it is a harness artifact, not an utterance.
+    #[test]
+    fn empty_and_whitespace_user_tails_are_not_user_turns() {
+        for content in ["", "   \n\t "] {
+            let msgs = messages_from(
+                "/v1/chat/completions",
+                serde_json::json!({
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "user", "content": "fix the bug"},
+                        {"role": "assistant", "content": "Fixed it."},
+                        {"role": "user", "content": content}
+                    ]
+                }),
+            );
+            assert!(!is_user_turn(&msgs), "content {content:?} opened a turn");
+        }
+    }
+
+    /// Every client API can deliver a user-role message with nothing in it — a null or
+    /// missing `content`, an empty parts array, an empty text block. None of them open a
+    /// turn, whatever the wire format.
+    #[test]
+    fn empty_user_content_is_not_a_user_turn_on_any_client_api() {
+        let chat = |content: serde_json::Value| {
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "content": "Fixed it."},
+                    {"role": "user", "content": content}
+                ]
+            })
+        };
+        let anthropic = |content: serde_json::Value| {
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "content": "Fixed it."},
+                    {"role": "user", "content": content}
+                ]
+            })
+        };
+        let responses = |content: serde_json::Value| {
+            serde_json::json!({
+                "model": "gpt-5.3-codex",
+                "input": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "content": "Fixed it."},
+                    {"role": "user", "content": content}
+                ]
+            })
+        };
+
+        let cases = [
+            ("/v1/chat/completions", chat(serde_json::Value::Null)),
+            ("/v1/chat/completions", chat(serde_json::json!(""))),
+            ("/v1/chat/completions", chat(serde_json::json!([]))),
+            (
+                "/v1/chat/completions",
+                chat(serde_json::json!([{"type": "text", "text": "  "}])),
+            ),
+            ("/v1/messages", anthropic(serde_json::json!(""))),
+            ("/v1/messages", anthropic(serde_json::json!([]))),
+            (
+                "/v1/messages",
+                anthropic(serde_json::json!([{"type": "text", "text": "\n"}])),
+            ),
+            ("/v1/responses", responses(serde_json::json!(""))),
+            ("/v1/responses", responses(serde_json::json!([]))),
+        ];
+
+        for (endpoint, body) in cases {
+            let msgs = messages_from(endpoint, body.clone());
+            assert!(
+                !is_user_turn(&msgs),
+                "{endpoint} opened a turn on {body}, normalized to {msgs:?}"
+            );
+        }
+    }
+
+    /// A pasted screenshot with no caption has no text to check, but the user did speak.
+    #[test]
+    fn attachment_only_user_tail_is_a_user_turn() {
+        const PNG: &str = "data:image/png;base64,iVBORw0KGgo=";
+
+        let cases = [
+            (
+                "/v1/chat/completions",
+                serde_json::json!({
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "user", "content": "fix the bug"},
+                        {"role": "assistant", "content": "Fixed it."},
+                        {"role": "user", "content": [
+                            {"type": "image_url", "image_url": {"url": PNG}}
+                        ]}
+                    ]
+                }),
+            ),
+            (
+                "/v1/messages",
+                serde_json::json!({
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 1024,
+                    "messages": [
+                        {"role": "user", "content": "fix the bug"},
+                        {"role": "assistant", "content": "Fixed it."},
+                        {"role": "user", "content": [
+                            {"type": "image", "source": {
+                                "type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="
+                            }}
+                        ]}
+                    ]
+                }),
+            ),
+        ];
+
+        for (endpoint, body) in cases {
+            let msgs = messages_from(endpoint, body.clone());
+            assert!(
+                is_user_turn(&msgs),
+                "{endpoint} pinned an attachment-only turn, normalized to {msgs:?}"
+            );
+        }
+    }
+
+    /// Bedrock reaches the same gate through the upstream shape rather than a client
+    /// endpoint, so cover its empty user messages directly.
+    #[test]
+    fn empty_bedrock_user_content_is_not_a_user_turn() {
+        use hermesllm::apis::amazon_bedrock::{
+            ContentBlock, ConversationRole, ConverseRequest, Message as BedrockMessage,
+        };
+
+        for tail in [
+            Vec::new(),
+            vec![ContentBlock::Text {
+                text: String::new(),
+            }],
+            vec![ContentBlock::Text {
+                text: "  \n".to_string(),
+            }],
+        ] {
+            let request = ConverseRequest {
+                model_id: "anthropic.claude-3-sonnet".to_string(),
+                messages: Some(vec![
+                    BedrockMessage {
+                        role: ConversationRole::User,
+                        content: vec![ContentBlock::Text {
+                            text: "fix the bug".to_string(),
+                        }],
+                    },
+                    BedrockMessage {
+                        role: ConversationRole::Assistant,
+                        content: vec![ContentBlock::Text {
+                            text: "Fixed it.".to_string(),
+                        }],
+                    },
+                    BedrockMessage {
+                        role: ConversationRole::User,
+                        content: tail.clone(),
+                    },
+                ]),
+                ..Default::default()
+            };
+
+            let msgs = ProviderRequestType::BedrockConverse(request).get_messages();
+            assert!(
+                !is_user_turn(&msgs),
+                "bedrock tail {tail:?} opened a turn, normalized to {msgs:?}"
+            );
+        }
+    }
+
+    /// Claude Code injects reminders and hook output as user-role text. On their own they
+    /// are not a new utterance, so the loop stays pinned.
+    #[test]
+    fn envelope_only_user_tail_is_not_a_user_turn() {
+        for content in [
+            "<system-reminder>\nYour todo list is empty.\n</system-reminder>",
+            "<user-prompt-submit-hook>blocked by hook</user-prompt-submit-hook>\n",
+            "<system-reminder>a</system-reminder> <system-reminder>b</system-reminder>",
+            // Truncated envelope: still harness output, not user text.
+            "<system-reminder>\nYour todo list is empty.",
+        ] {
+            let msgs = messages_from(
+                "/v1/chat/completions",
+                serde_json::json!({
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "user", "content": "fix the bug"},
+                        {"role": "assistant", "content": "Fixed it."},
+                        {"role": "user", "content": content}
+                    ]
+                }),
+            );
+            assert!(!is_user_turn(&msgs), "content {content:?} opened a turn");
+        }
+    }
+
+    /// A reminder rides alongside real user text on genuine turns; that still routes.
+    #[test]
+    fn envelope_plus_user_text_is_a_user_turn() {
+        let msgs = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "content": "Fixed it."},
+                    {"role": "user", "content": "<system-reminder>\nTodo list is empty.\n</system-reminder>\nnow write the tests"}
+                ]
+            }),
+        );
+        assert!(is_user_turn(&msgs));
+    }
+
+    /// Claude Code's usual continuation shape: a tool result packed with a reminder and
+    /// no user text. The reminder must not be mistaken for a new turn.
+    #[test]
+    fn anthropic_tool_result_with_reminder_only_is_a_continuation() {
+        let msgs = messages_from(
+            "/v1/messages",
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"role": "assistant", "content": [
+                        {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                         "input": {"path": "main.rs"}}
+                    ]},
+                    {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "fn main() {}"},
+                        {"type": "text", "text": "<system-reminder>\nYour todo list has changed.\n</system-reminder>"}
+                    ]}
                 ]
             }),
         );

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -88,50 +88,42 @@ pub fn resolve_session(
     }
 }
 
-/// Whether this request continues an agentic tool loop rather than opening a fresh user
-/// turn.
+/// Whether this request is a fresh user turn and should go through the quality router.
 ///
-/// Coding agents issue one LLM call per step of a single user turn — the model answers
-/// with tool calls, the client runs them and posts the results back for the next step.
-/// Every client shape lands on the same marker once normalized by
-/// [`hermesllm::ProviderRequest::get_messages`]: Anthropic `tool_result` blocks, OpenAI
-/// Chat `role: "tool"` messages, and Responses `function_call_output` items all become a
-/// trailing [`Role::Tool`] message.
-///
-/// Only the tail is examined. Earlier turns leave their tool traffic in the history, so
-/// "contains a tool message" would mark every later turn of a long conversation as a
-/// continuation. A request that ends in anything else — most importantly new user text
-/// packed alongside tool results — is a fresh turn and routes normally.
-pub fn is_tool_loop_continuation(messages: &[Message]) -> bool {
-    matches!(messages.last(), Some(m) if m.role == Role::Tool)
+/// Only the tail is examined. A trailing [`Role::User`] is a new utterance — including
+/// Anthropic packing new user text alongside `tool_result` blocks, which normalizes to
+/// a trailing user message. Anything else (tool results, assistant output, empty
+/// history) is not a user turn; routing is skipped and the prior decision is replayed
+/// when a warm binding exists.
+pub fn is_user_turn(messages: &[Message]) -> bool {
+    matches!(messages.last(), Some(m) if m.role == Role::User)
 }
 
-/// A routing decision carried over from an earlier step of the same tool loop.
+/// Whether this request should skip the quality router and replay the prior decision.
+/// Off unless `routing.route_on_user_turn` is enabled, and only then for non-user tails.
+pub fn should_reuse_prior_decision(enabled: bool, messages: &[Message]) -> bool {
+    enabled && !is_user_turn(messages)
+}
+
+/// A routing decision carried over from an earlier request in the same session.
 pub struct LoopReuse {
-    /// The model this loop is already running on.
+    /// The model this session is already running on.
     pub model: String,
     /// The route that picked it, replayed so telemetry stays attributed to it.
     pub route_name: Option<String>,
 }
 
-/// The decision to reuse for a tool-loop continuation, or `None` when this request must
+/// The decision to reuse when this is not a user turn, or `None` when the request must
 /// go through the quality router.
-///
-/// Re-running quality routing on every step of a loop lets one user turn drift across
-/// models mid-generation, which breaks the client: tool-call ids, reasoning state and
-/// provider prompt caches are all tied to the model that started the turn. So a
-/// continuation replays the model this loop already chose instead of asking the router
-/// again — which also skips the router call entirely.
 ///
 /// Reuse is deliberately conservative; anything unexpected falls through to a normal
 /// route rather than risk pinning a request to the wrong model:
 ///
 /// * no session key (nothing to reuse from, e.g. `X-Plano-Cache: off`),
-/// * no binding, or one whose cache went cold or whose prompt prefix drifted — the loop
-///   is no longer recognizable, so treat this as a fresh decision,
+/// * no binding, or one whose cache went cold or whose prompt prefix drifted,
 /// * a different model lane than the one that wrote the binding (see
 ///   [`SessionBinding::requested_model`]).
-pub async fn reuse_for_tool_loop(
+pub async fn reuse_prior_decision(
     orchestrator: &OrchestratorService,
     session_id: Option<&str>,
     tenant_id: Option<&str>,
@@ -145,7 +137,7 @@ pub async fn reuse_for_tool_loop(
         debug!(
             binding_lane = %binding.requested_model,
             request_lane = %requested_model,
-            "tool-loop reuse declined — request is on a different model lane"
+            "prior-decision reuse declined — request is on a different model lane"
         );
         return None;
     }
@@ -162,7 +154,7 @@ pub async fn reuse_for_tool_loop(
     if !warm || drifted {
         debug!(
             warm,
-            drifted, "tool-loop reuse declined — session is no longer warm on this prefix"
+            drifted, "prior-decision reuse declined — session is no longer warm on this prefix"
         );
         return None;
     }
@@ -195,7 +187,7 @@ pub struct RouteFacts<'a> {
     pub candidate_model: &'a str,
     pub candidate_route: Option<&'a str>,
     /// The model the client asked for, after alias resolution and before routing had a
-    /// say. Persisted as the binding's lane so a later tool-loop continuation on a
+    /// say. Persisted as the binding's lane so a later non-user turn on a
     /// different lane doesn't inherit this decision.
     pub requested_model: &'a str,
 }
@@ -1113,11 +1105,10 @@ mod tests {
         );
     }
 
-    // ---- is_tool_loop_continuation() ----
+    // ---- is_user_turn() ----
     //
     // Driven through the real client-API parsers rather than hand-built `Message`s: the
-    // predicate's whole premise is that every agent wire format collapses to a trailing
-    // `Role::Tool` once normalized, so the conversion is the part worth testing.
+    // gate is "last role is user", and every agent wire format has to normalize to that.
 
     use hermesllm::clients::SupportedAPIsFromClient;
     use hermesllm::{ProviderRequest, ProviderRequestType};
@@ -1150,7 +1141,7 @@ mod tests {
                 ]
             }),
         );
-        assert!(is_tool_loop_continuation(&msgs));
+        assert!(!is_user_turn(&msgs));
     }
 
     /// Anthropic packs a tool result and new user text into one message. The user spoke
@@ -1175,7 +1166,7 @@ mod tests {
                 ]
             }),
         );
-        assert!(!is_tool_loop_continuation(&msgs));
+        assert!(is_user_turn(&msgs));
     }
 
     /// Cline / Cursor on OpenAI Chat Completions.
@@ -1195,11 +1186,11 @@ mod tests {
                 ]
             }),
         );
-        assert!(is_tool_loop_continuation(&msgs));
+        assert!(!is_user_turn(&msgs));
     }
 
     /// Tool traffic from earlier turns stays in the history forever; only the tail marks
-    /// a continuation, otherwise every later turn of a long session would be pinned.
+    /// a user turn, otherwise every later turn of a long session would be pinned.
     #[test]
     fn chat_fresh_user_turn_after_earlier_tools_is_not_a_continuation() {
         let msgs = messages_from(
@@ -1218,7 +1209,7 @@ mod tests {
                 ]
             }),
         );
-        assert!(!is_tool_loop_continuation(&msgs));
+        assert!(is_user_turn(&msgs));
     }
 
     /// Codex / OpenCode on the Responses API.
@@ -1238,11 +1229,11 @@ mod tests {
                 ]
             }),
         );
-        assert!(is_tool_loop_continuation(&msgs));
+        assert!(!is_user_turn(&msgs));
     }
 
     #[test]
-    fn plain_user_turn_and_empty_history_are_not_continuations() {
+    fn plain_user_turn_routes_and_empty_history_does_not() {
         let msgs = messages_from(
             "/v1/chat/completions",
             serde_json::json!({
@@ -1250,11 +1241,55 @@ mod tests {
                 "messages": [{"role": "user", "content": "write a haiku"}]
             }),
         );
-        assert!(!is_tool_loop_continuation(&msgs));
-        assert!(!is_tool_loop_continuation(&[]));
+        assert!(is_user_turn(&msgs));
+        assert!(!is_user_turn(&[]));
     }
 
-    // ---- reuse_for_tool_loop() ----
+    /// An assistant-only tail is not a user turn, so routing is skipped.
+    #[test]
+    fn reuse_is_off_unless_route_on_user_turn_is_enabled() {
+        let tool_tail = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "call_1", "type": "function",
+                         "function": {"name": "read_file", "arguments": "{}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_1", "content": "ok"}
+                ]
+            }),
+        );
+        let user_tail = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "fix the bug"}]
+            }),
+        );
+        assert!(!should_reuse_prior_decision(false, &tool_tail));
+        assert!(should_reuse_prior_decision(true, &tool_tail));
+        assert!(!should_reuse_prior_decision(true, &user_tail));
+    }
+
+    #[test]
+    fn assistant_tail_is_not_a_user_turn() {
+        let msgs = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug"},
+                    {"role": "assistant", "content": "Looking at main.rs"}
+                ]
+            }),
+        );
+        assert!(!is_user_turn(&msgs));
+    }
+
+    // ---- reuse_prior_decision() ----
 
     /// Seed the binding a first turn would have written: the client asked for
     /// `requested_model`, routing sent the turn to `anchor`.
@@ -1294,7 +1329,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 5).await;
 
-        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+        let reuse = reuse_prior_decision(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
             .await
             .expect("warm same-lane binding should be reused");
         assert_eq!(reuse.model, "openai/pricey");
@@ -1308,7 +1343,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, CLIENT_MODEL, None, 5).await;
 
-        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+        let reuse = reuse_prior_decision(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
             .await
             .expect("an unrouted turn still anchors the loop");
         assert_eq!(reuse.model, CLIENT_MODEL);
@@ -1322,7 +1357,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 5).await;
 
-        let reuse = reuse_for_tool_loop(
+        let reuse = reuse_prior_decision(
             &orch,
             Some("s1"),
             None,
@@ -1340,7 +1375,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", None, 24 * 3600).await;
 
-        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL).await;
+        let reuse = reuse_prior_decision(&orch, Some("s1"), None, Some(1), CLIENT_MODEL).await;
         assert!(reuse.is_none());
     }
 
@@ -1351,7 +1386,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", None, 5).await;
 
-        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(999), CLIENT_MODEL).await;
+        let reuse = reuse_prior_decision(&orch, Some("s1"), None, Some(999), CLIENT_MODEL).await;
         assert!(reuse.is_none());
     }
 
@@ -1361,12 +1396,12 @@ mod tests {
     async fn without_a_session_or_binding_there_is_nothing_to_reuse() {
         let orch = orch_with_rates();
         assert!(
-            reuse_for_tool_loop(&orch, None, None, Some(1), CLIENT_MODEL)
+            reuse_prior_decision(&orch, None, None, Some(1), CLIENT_MODEL)
                 .await
                 .is_none()
         );
         assert!(
-            reuse_for_tool_loop(&orch, Some("never-seen"), None, Some(1), CLIENT_MODEL)
+            reuse_prior_decision(&orch, Some("never-seen"), None, Some(1), CLIENT_MODEL)
                 .await
                 .is_none()
         );
@@ -1379,7 +1414,7 @@ mod tests {
         let orch = orch_with_rates();
         seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 30).await;
 
-        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+        let reuse = reuse_prior_decision(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
             .await
             .unwrap();
         let d = route(&orch, None, facts_for(&reuse.model)).await;

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -100,7 +100,7 @@ pub fn is_user_turn(messages: &[Message]) -> bool {
 }
 
 /// Whether this request should skip the quality router and replay the prior decision.
-/// Off unless `routing.auto_pin_tool_calls` is enabled, and only then for non-user tails.
+/// Off unless `routing.route_on_user_only` is enabled, and only then for non-user tails.
 pub fn should_reuse_prior_decision(enabled: bool, messages: &[Message]) -> bool {
     enabled && !is_user_turn(messages)
 }
@@ -1247,7 +1247,7 @@ mod tests {
 
     /// An assistant-only tail is not a user turn, so routing is skipped.
     #[test]
-    fn reuse_is_off_unless_auto_pin_tool_calls_is_enabled() {
+    fn reuse_is_off_unless_route_on_user_only_is_enabled() {
         let tool_tail = messages_from(
             "/v1/chat/completions",
             serde_json::json!({

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -27,7 +27,7 @@
 use std::time::{Duration, SystemTime};
 
 use common::configuration::EffectiveRoutingBudget;
-use hermesllm::apis::openai::Message;
+use hermesllm::apis::openai::{Message, Role};
 use hermesllm::{provider_cache_capability, ProviderCacheCapability, ProviderId};
 use opentelemetry::trace::get_active_span;
 use opentelemetry::KeyValue;
@@ -88,6 +88,91 @@ pub fn resolve_session(
     }
 }
 
+/// Whether this request continues an agentic tool loop rather than opening a fresh user
+/// turn.
+///
+/// Coding agents issue one LLM call per step of a single user turn — the model answers
+/// with tool calls, the client runs them and posts the results back for the next step.
+/// Every client shape lands on the same marker once normalized by
+/// [`hermesllm::ProviderRequest::get_messages`]: Anthropic `tool_result` blocks, OpenAI
+/// Chat `role: "tool"` messages, and Responses `function_call_output` items all become a
+/// trailing [`Role::Tool`] message.
+///
+/// Only the tail is examined. Earlier turns leave their tool traffic in the history, so
+/// "contains a tool message" would mark every later turn of a long conversation as a
+/// continuation. A request that ends in anything else — most importantly new user text
+/// packed alongside tool results — is a fresh turn and routes normally.
+pub fn is_tool_loop_continuation(messages: &[Message]) -> bool {
+    matches!(messages.last(), Some(m) if m.role == Role::Tool)
+}
+
+/// A routing decision carried over from an earlier step of the same tool loop.
+pub struct LoopReuse {
+    /// The model this loop is already running on.
+    pub model: String,
+    /// The route that picked it, replayed so telemetry stays attributed to it.
+    pub route_name: Option<String>,
+}
+
+/// The decision to reuse for a tool-loop continuation, or `None` when this request must
+/// go through the quality router.
+///
+/// Re-running quality routing on every step of a loop lets one user turn drift across
+/// models mid-generation, which breaks the client: tool-call ids, reasoning state and
+/// provider prompt caches are all tied to the model that started the turn. So a
+/// continuation replays the model this loop already chose instead of asking the router
+/// again — which also skips the router call entirely.
+///
+/// Reuse is deliberately conservative; anything unexpected falls through to a normal
+/// route rather than risk pinning a request to the wrong model:
+///
+/// * no session key (nothing to reuse from, e.g. `X-Plano-Cache: off`),
+/// * no binding, or one whose cache went cold or whose prompt prefix drifted — the loop
+///   is no longer recognizable, so treat this as a fresh decision,
+/// * a different model lane than the one that wrote the binding (see
+///   [`SessionBinding::requested_model`]).
+pub async fn reuse_for_tool_loop(
+    orchestrator: &OrchestratorService,
+    session_id: Option<&str>,
+    tenant_id: Option<&str>,
+    prefix_hash: Option<u64>,
+    requested_model: &str,
+) -> Option<LoopReuse> {
+    let session_id = session_id?;
+    let binding = orchestrator.peek_binding(session_id, tenant_id).await?;
+
+    if binding.requested_model != requested_model {
+        debug!(
+            binding_lane = %binding.requested_model,
+            request_lane = %requested_model,
+            "tool-loop reuse declined — request is on a different model lane"
+        );
+        return None;
+    }
+
+    let (warm, _) = warmth(
+        &binding,
+        &capability_for_model(&binding.anchor_model),
+        SystemTime::now(),
+    );
+    let drifted = matches!(
+        (binding.prefix_hash, prefix_hash),
+        (Some(stored), Some(current)) if stored != current
+    );
+    if !warm || drifted {
+        debug!(
+            warm,
+            drifted, "tool-loop reuse declined — session is no longer warm on this prefix"
+        );
+        return None;
+    }
+
+    Some(LoopReuse {
+        model: binding.anchor_model,
+        route_name: binding.route_name,
+    })
+}
+
 /// Extra memory retention beyond the warmth window, so a still-warm binding is never
 /// GC'd out from under the router before it could plausibly go cold.
 const GC_SLACK: Duration = Duration::from_secs(60);
@@ -109,6 +194,10 @@ pub struct RouteFacts<'a> {
     /// The model the quality router picked for this request.
     pub candidate_model: &'a str,
     pub candidate_route: Option<&'a str>,
+    /// The model the client asked for, after alias resolution and before routing had a
+    /// say. Persisted as the binding's lane so a later tool-loop continuation on a
+    /// different lane doesn't inherit this decision.
+    pub requested_model: &'a str,
 }
 
 /// The routing decision plus the session state to carry into the response side.
@@ -119,6 +208,9 @@ pub struct RouteDecision {
     /// The session's never-switch model for this episode — carried to the response side
     /// so the usage-refresh preserves it on the binding.
     pub default_model: String,
+    /// The binding's model lane — carried to the response side so the usage-refresh
+    /// preserves it (see [`SessionBinding::requested_model`]).
+    pub requested_model: String,
     /// Whether the session's cache was inferred warm at decision time.
     pub warm: bool,
     /// Cumulative never-switch baseline (USD) after this decision.
@@ -211,6 +303,7 @@ pub async fn route(
             model: facts.candidate_model.to_string(),
             route_name: facts.candidate_route.map(str::to_string),
             default_model: facts.candidate_model.to_string(),
+            requested_model: facts.requested_model.to_string(),
             warm: false,
             baseline_usd: 0.0,
             switch_spend_usd: 0.0,
@@ -518,6 +611,7 @@ pub async fn route(
             SessionBinding {
                 anchor_model: model.clone(),
                 default_model: default_model.clone(),
+                requested_model: facts.requested_model.to_string(),
                 route_name: route_name.clone(),
                 prefix_hash: facts.prefix_hash,
                 last_used: now,
@@ -536,6 +630,7 @@ pub async fn route(
         model,
         route_name,
         default_model,
+        requested_model: facts.requested_model.to_string(),
         warm: effective_warm,
         baseline_usd,
         switch_spend_usd,
@@ -560,10 +655,14 @@ mod tests {
         }
     }
 
+    /// The model lane test requests run on — what the client asked for, before routing.
+    const CLIENT_MODEL: &str = "anthropic/claude-sonnet-4-5";
+
     fn binding_used_ago(secs: u64) -> SessionBinding {
         SessionBinding {
             anchor_model: "anthropic/claude-sonnet-4-5".to_string(),
             default_model: "anthropic/claude-sonnet-4-5".to_string(),
+            requested_model: CLIENT_MODEL.to_string(),
             route_name: None,
             prefix_hash: Some(1),
             last_used: SystemTime::now() - Duration::from_secs(secs),
@@ -684,6 +783,7 @@ mod tests {
             SessionBinding {
                 anchor_model: "anthropic/expensive".to_string(),
                 default_model: "anthropic/expensive".to_string(),
+                requested_model: CLIENT_MODEL.to_string(),
                 route_name: None,
                 prefix_hash: Some(1),
                 last_used: SystemTime::now() - Duration::from_secs(idle_secs),
@@ -707,6 +807,7 @@ mod tests {
             context_tokens: 0,
             candidate_model: candidate,
             candidate_route: None,
+            requested_model: CLIENT_MODEL,
         }
     }
 
@@ -794,6 +895,7 @@ mod tests {
             context_tokens: 0,
             candidate_model: "openai/pricey",
             candidate_route: None,
+            requested_model: CLIENT_MODEL,
         };
         let d = route(&orch, Some(&st), facts).await;
         assert_eq!(d.model, "openai/pricey");
@@ -812,6 +914,7 @@ mod tests {
             SessionBinding {
                 anchor_model: "google/cheap".to_string(),
                 default_model: "anthropic/expensive".to_string(),
+                requested_model: CLIENT_MODEL.to_string(),
                 route_name: None,
                 prefix_hash: Some(1),
                 last_used: SystemTime::now(),
@@ -855,6 +958,7 @@ mod tests {
             SessionBinding {
                 anchor_model: "anthropic/expensive".to_string(),
                 default_model: "anthropic/expensive".to_string(),
+                requested_model: CLIENT_MODEL.to_string(),
                 route_name: None,
                 prefix_hash: Some(1),
                 last_used: SystemTime::now() - Duration::from_secs(30),
@@ -908,6 +1012,7 @@ mod tests {
             context_tokens: 100_000,
             candidate_model: candidate,
             candidate_route: None,
+            requested_model: CLIENT_MODEL,
         };
 
         // Turn 1 — cold start: no binding yet, the candidate is honored and becomes both
@@ -1005,6 +1110,289 @@ mod tests {
             d.switch_spend_usd,
             st.max_overhead_pct,
             d.baseline_usd
+        );
+    }
+
+    // ---- is_tool_loop_continuation() ----
+    //
+    // Driven through the real client-API parsers rather than hand-built `Message`s: the
+    // predicate's whole premise is that every agent wire format collapses to a trailing
+    // `Role::Tool` once normalized, so the conversion is the part worth testing.
+
+    use hermesllm::clients::SupportedAPIsFromClient;
+    use hermesllm::{ProviderRequest, ProviderRequestType};
+
+    fn messages_from(endpoint: &str, body: serde_json::Value) -> Vec<Message> {
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let client_api = SupportedAPIsFromClient::from_endpoint(endpoint).unwrap();
+        ProviderRequestType::try_from((&bytes[..], &client_api))
+            .expect("request should parse")
+            .get_messages()
+    }
+
+    /// Claude Code posting a tool result back for the next step of the same turn.
+    #[test]
+    fn anthropic_tool_result_is_a_continuation() {
+        let msgs = messages_from(
+            "/v1/messages",
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"role": "assistant", "content": [
+                        {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                         "input": {"path": "main.rs"}}
+                    ]},
+                    {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "fn main() {}"}
+                    ]}
+                ]
+            }),
+        );
+        assert!(is_tool_loop_continuation(&msgs));
+    }
+
+    /// Anthropic packs a tool result and new user text into one message. The user spoke
+    /// again, so this opens a fresh turn and must route normally.
+    #[test]
+    fn anthropic_tool_result_with_new_user_text_is_a_fresh_turn() {
+        let msgs = messages_from(
+            "/v1/messages",
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"role": "assistant", "content": [
+                        {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                         "input": {"path": "main.rs"}}
+                    ]},
+                    {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "fn main() {}"},
+                        {"type": "text", "text": "actually, explain the error handling too"}
+                    ]}
+                ]
+            }),
+        );
+        assert!(!is_tool_loop_continuation(&msgs));
+    }
+
+    /// Cline / Cursor on OpenAI Chat Completions.
+    #[test]
+    fn chat_tool_role_is_a_continuation() {
+        let msgs = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "call_1", "type": "function",
+                         "function": {"name": "read_file", "arguments": "{\"path\":\"main.rs\"}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_1", "content": "fn main() {}"}
+                ]
+            }),
+        );
+        assert!(is_tool_loop_continuation(&msgs));
+    }
+
+    /// Tool traffic from earlier turns stays in the history forever; only the tail marks
+    /// a continuation, otherwise every later turn of a long session would be pinned.
+    #[test]
+    fn chat_fresh_user_turn_after_earlier_tools_is_not_a_continuation() {
+        let msgs = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "call_1", "type": "function",
+                         "function": {"name": "read_file", "arguments": "{}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_1", "content": "fn main() {}"},
+                    {"role": "assistant", "content": "Fixed it."},
+                    {"role": "user", "content": "now write the tests"}
+                ]
+            }),
+        );
+        assert!(!is_tool_loop_continuation(&msgs));
+    }
+
+    /// Codex / OpenCode on the Responses API.
+    #[test]
+    fn responses_function_call_output_is_a_continuation() {
+        let msgs = messages_from(
+            "/v1/responses",
+            serde_json::json!({
+                "model": "gpt-5.3-codex",
+                "input": [
+                    {"role": "user", "content": "fix the bug in main.rs"},
+                    {"type": "function_call", "call_id": "call_1", "name": "exec_command",
+                     "arguments": "{\"cmd\":\"cat main.rs\"}"},
+                    {"type": "function_call_output", "call_id": "call_1",
+                     "output": {"stdout": "fn main() {}"}}
+                ]
+            }),
+        );
+        assert!(is_tool_loop_continuation(&msgs));
+    }
+
+    #[test]
+    fn plain_user_turn_and_empty_history_are_not_continuations() {
+        let msgs = messages_from(
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "write a haiku"}]
+            }),
+        );
+        assert!(!is_tool_loop_continuation(&msgs));
+        assert!(!is_tool_loop_continuation(&[]));
+    }
+
+    // ---- reuse_for_tool_loop() ----
+
+    /// Seed the binding a first turn would have written: the client asked for
+    /// `requested_model`, routing sent the turn to `anchor`.
+    async fn seed_lane_binding(
+        orch: &OrchestratorService,
+        requested_model: &str,
+        anchor: &str,
+        route_name: Option<&str>,
+        idle_secs: u64,
+    ) {
+        orch.store_binding(
+            "s1",
+            None,
+            SessionBinding {
+                anchor_model: anchor.to_string(),
+                default_model: anchor.to_string(),
+                requested_model: requested_model.to_string(),
+                route_name: route_name.map(str::to_string),
+                prefix_hash: Some(1),
+                last_used: SystemTime::now() - Duration::from_secs(idle_secs),
+                cached_tokens: 100_000,
+                baseline_usd: 0.0,
+                switch_spend_usd: 0.0,
+                switches: 0,
+                session_cost_usd: 0.0,
+                history: Vec::new(),
+            },
+            Some(Duration::from_secs(3600)),
+        )
+        .await;
+    }
+
+    /// The core case: the client keeps asking for Sonnet, routing sent turn 1 to a
+    /// different model, and the rest of the loop replays that model instead of re-routing.
+    #[tokio::test]
+    async fn warm_binding_on_the_same_lane_is_reused() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 5).await;
+
+        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+            .await
+            .expect("warm same-lane binding should be reused");
+        assert_eq!(reuse.model, "openai/pricey");
+        assert_eq!(reuse.route_name.as_deref(), Some("code gen"));
+    }
+
+    /// When no route matched, the first turn dispatches the client's own model and stores
+    /// it as the anchor — continuations must replay that too.
+    #[tokio::test]
+    async fn unrouted_first_turn_is_reused() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, CLIENT_MODEL, None, 5).await;
+
+        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+            .await
+            .expect("an unrouted turn still anchors the loop");
+        assert_eq!(reuse.model, CLIENT_MODEL);
+        assert!(reuse.route_name.is_none());
+    }
+
+    /// Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` side calls ride the same prompt prefix
+    /// as the main loop. They must not inherit the main loop's model.
+    #[tokio::test]
+    async fn a_different_model_lane_is_not_reused() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 5).await;
+
+        let reuse = reuse_for_tool_loop(
+            &orch,
+            Some("s1"),
+            None,
+            Some(1),
+            "anthropic/claude-haiku-4-5",
+        )
+        .await;
+        assert!(reuse.is_none(), "the small-fast lane must route on its own");
+    }
+
+    /// The loop paused long enough for the provider cache to lapse: the binding no longer
+    /// describes a live loop, so fall back to a fresh routing decision.
+    #[tokio::test]
+    async fn a_cold_binding_is_not_reused() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", None, 24 * 3600).await;
+
+        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL).await;
+        assert!(reuse.is_none());
+    }
+
+    /// A changed system prompt or tool set means this is a different conversation that
+    /// merely collided on the session key.
+    #[tokio::test]
+    async fn a_drifted_prefix_is_not_reused() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", None, 5).await;
+
+        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(999), CLIENT_MODEL).await;
+        assert!(reuse.is_none());
+    }
+
+    /// No session key (`X-Plano-Cache: off`, or nothing to anchor on) and no binding both
+    /// mean there is nothing to replay.
+    #[tokio::test]
+    async fn without_a_session_or_binding_there_is_nothing_to_reuse() {
+        let orch = orch_with_rates();
+        assert!(
+            reuse_for_tool_loop(&orch, None, None, Some(1), CLIENT_MODEL)
+                .await
+                .is_none()
+        );
+        assert!(
+            reuse_for_tool_loop(&orch, Some("never-seen"), None, Some(1), CLIENT_MODEL)
+                .await
+                .is_none()
+        );
+    }
+
+    /// Skipping the router must not skip session bookkeeping: feeding the replayed model
+    /// back through `route()` keeps the session on it and refreshes the binding.
+    #[tokio::test]
+    async fn replaying_the_loop_model_refreshes_the_binding_without_switching() {
+        let orch = orch_with_rates();
+        seed_lane_binding(&orch, CLIENT_MODEL, "openai/pricey", Some("code gen"), 30).await;
+
+        let reuse = reuse_for_tool_loop(&orch, Some("s1"), None, Some(1), CLIENT_MODEL)
+            .await
+            .unwrap();
+        let d = route(&orch, None, facts_for(&reuse.model)).await;
+
+        assert_eq!(d.model, "openai/pricey");
+        assert_eq!(d.switches, 0, "replaying the anchor is not a switch");
+        assert!(d.warm);
+
+        let stored = orch.get_binding("s1", None).await.unwrap();
+        assert_eq!(stored.anchor_model, "openai/pricey");
+        assert_eq!(stored.requested_model, CLIENT_MODEL);
+        assert!(
+            stored.last_used.elapsed().unwrap() < Duration::from_secs(5),
+            "the binding should have been refreshed"
         );
     }
 }

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -100,7 +100,7 @@ pub fn is_user_turn(messages: &[Message]) -> bool {
 }
 
 /// Whether this request should skip the quality router and replay the prior decision.
-/// Off unless `routing.route_on_user_turn` is enabled, and only then for non-user tails.
+/// Off unless `routing.auto_pin_tool_calls` is enabled, and only then for non-user tails.
 pub fn should_reuse_prior_decision(enabled: bool, messages: &[Message]) -> bool {
     enabled && !is_user_turn(messages)
 }
@@ -1247,7 +1247,7 @@ mod tests {
 
     /// An assistant-only tail is not a user turn, so routing is skipped.
     #[test]
-    fn reuse_is_off_unless_route_on_user_turn_is_enabled() {
+    fn reuse_is_off_unless_auto_pin_tool_calls_is_enabled() {
         let tool_tail = messages_from(
             "/v1/chat/completions",
             serde_json::json!({

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -72,7 +72,7 @@ pub async fn routing_decision(
     span_attributes: &Option<SpanAttributes>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
-    route_on_user_turn: bool,
+    auto_pin_tool_calls: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     let request_headers = request.headers().clone();
     let request_id: String = request_headers
@@ -113,7 +113,7 @@ pub async fn routing_decision(
         tenant_id,
         prompt_caching,
         routing_budget,
-        route_on_user_turn,
+        auto_pin_tool_calls,
     )
     .instrument(request_span)
     .await
@@ -131,7 +131,7 @@ async fn routing_decision_inner(
     tenant_id: Option<String>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
-    route_on_user_turn: bool,
+    auto_pin_tool_calls: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     set_service_name(operation_component::ROUTING);
     let routing_budget =
@@ -209,7 +209,7 @@ async fn routing_decision_inner(
         inline_routing_preferences.is_some() || orchestrator_service.has_routing_preferences();
     let implicit_affinity_enabled = prompt_caching.session_affinity
         || routing_budget.is_some()
-        || (route_on_user_turn && routing_can_override_model);
+        || (auto_pin_tool_calls && routing_can_override_model);
     let session_router::SessionResolution {
         request_prefix_hash,
         session_id,
@@ -230,10 +230,10 @@ async fn routing_decision_inner(
         0
     };
 
-    // Mirror the proxy path: opt-in (`routing.route_on_user_turn`) skips the router
+    // Mirror the proxy path: opt-in (`routing.auto_pin_tool_calls`) skips the router
     // on non-user tails and replays the prior decision.
     let loop_reuse =
-        if session_router::should_reuse_prior_decision(route_on_user_turn, &request_messages) {
+        if session_router::should_reuse_prior_decision(auto_pin_tool_calls, &request_messages) {
             session_router::reuse_prior_decision(
                 &orchestrator_service,
                 session_id.as_deref(),

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use common::configuration::{
-    EffectivePromptCaching, EffectiveRoutingBudget, SpanAttributes, TopLevelRoutingPreference,
+    EffectivePromptCaching, EffectiveRoutingBudget, ModelAlias, SpanAttributes,
+    TopLevelRoutingPreference,
 };
 use common::consts::{MODEL_AFFINITY_HEADER, REQUEST_ID_HEADER};
 use common::errors::BrightStaffError;
@@ -9,11 +10,13 @@ use hermesllm::{ProviderRequest, ProviderRequestType};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, StatusCode};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, info_span, warn, Instrument};
 
 use super::extract_or_generate_traceparent;
 use crate::handlers::llm::model_selection::{router_chat_get_upstream_model, RoutingResult};
+use crate::handlers::llm::resolve_model_alias;
 use crate::handlers::llm::session_router;
 use crate::handlers::routing_budget_request;
 use crate::metrics as bs_metrics;
@@ -73,6 +76,7 @@ pub async fn routing_decision(
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
     route_on_user_only: bool,
+    model_aliases: &Option<HashMap<String, ModelAlias>>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     let request_headers = request.headers().clone();
     let request_id: String = request_headers
@@ -114,6 +118,7 @@ pub async fn routing_decision(
         prompt_caching,
         routing_budget,
         route_on_user_only,
+        model_aliases,
     )
     .instrument(request_span)
     .await
@@ -132,6 +137,7 @@ async fn routing_decision_inner(
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
     route_on_user_only: bool,
+    model_aliases: &Option<HashMap<String, ModelAlias>>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     set_service_name(operation_component::ROUTING);
     let routing_budget =
@@ -222,7 +228,10 @@ async fn routing_decision_inner(
         cache_off_for_request,
     );
 
-    let requested_model = client_request.model().to_string();
+    // Resolve the alias before it is used as the session's model lane: the proxy path
+    // stores bindings under the resolved model, so an unresolved alias here would look
+    // like a different lane and refuse every replay.
+    let requested_model = resolve_model_alias(client_request.model(), model_aliases);
 
     let context_tokens: u64 = if session_id.is_some() && routing_budget.is_some() {
         session_router::actual_context_tokens(&request_messages, &requested_model)
@@ -508,5 +517,32 @@ mod tests {
         assert!(parsed["route"].is_null());
         assert!(parsed.get("session_id").is_none());
         assert_eq!(parsed["pinned"], false);
+    }
+
+    /// The lane a decision is stored under must be the resolved model, matching the
+    /// proxy path. An unresolved alias reads as a different lane, so every
+    /// `route_on_user_only` replay would be refused and each step would re-route.
+    #[test]
+    fn alias_is_resolved_before_becoming_the_session_lane() {
+        let aliases = Some(HashMap::from([(
+            "arch.codex.default".to_string(),
+            ModelAlias {
+                target: "openai/gpt-5.4".to_string(),
+            },
+        )]));
+
+        let body = br#"{"model":"arch.codex.default","messages":[{"role":"user","content":"hi"}]}"#;
+        let (cleaned, _) = extract_routing_policy(body).unwrap();
+        let client_request = ProviderRequestType::try_from((
+            &cleaned[..],
+            &SupportedAPIsFromClient::from_endpoint("/v1/chat/completions").unwrap(),
+        ))
+        .unwrap();
+
+        assert_eq!(client_request.model(), "arch.codex.default");
+        assert_eq!(
+            resolve_model_alias(client_request.model(), &aliases),
+            "openai/gpt-5.4"
+        );
     }
 }

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tracing::{debug, info, info_span, warn, Instrument};
 
 use super::extract_or_generate_traceparent;
-use crate::handlers::llm::model_selection::router_chat_get_upstream_model;
+use crate::handlers::llm::model_selection::{router_chat_get_upstream_model, RoutingResult};
 use crate::handlers::llm::session_router;
 use crate::metrics as bs_metrics;
 use crate::metrics::labels as metric_labels;
@@ -197,8 +197,12 @@ async fn routing_decision_inner(
     // Session key + prefix hash resolved identically to the LLM handler so pins
     // interoperate across the full-proxy and decision paths.
     // Derive the implicit session key when either prompt-caching affinity or the routing
-    // budget is active, so the budget works the same way with caching off.
-    let implicit_affinity_enabled = prompt_caching.session_affinity || routing_budget.is_some();
+    // budget is active, so the budget works the same way with caching off — and whenever
+    // routing preferences are in play, so an agentic tool loop can replay its decision.
+    let routing_can_override_model =
+        inline_routing_preferences.is_some() || orchestrator_service.has_routing_preferences();
+    let implicit_affinity_enabled =
+        prompt_caching.session_affinity || routing_budget.is_some() || routing_can_override_model;
     let session_router::SessionResolution {
         request_prefix_hash,
         session_id,
@@ -211,20 +215,54 @@ async fn routing_decision_inner(
         cache_off_for_request,
     );
 
+    let requested_model = client_request.model().to_string();
+
     let context_tokens: u64 = if session_id.is_some() && routing_budget.is_some() {
-        session_router::actual_context_tokens(&request_messages, client_request.model())
+        session_router::actual_context_tokens(&request_messages, &requested_model)
     } else {
         0
     };
 
-    let routing_result = router_chat_get_upstream_model(
-        Arc::clone(&orchestrator_service),
-        client_request,
-        &request_path,
-        &request_id,
-        inline_routing_preferences,
-    )
-    .await;
+    // Mirror the proxy path: a step of an agentic tool loop replays the decision the loop
+    // already made rather than re-running the router, so callers polling this endpoint
+    // between tool calls get a stable answer for the whole turn.
+    let loop_reuse = if session_router::is_tool_loop_continuation(&request_messages) {
+        session_router::reuse_for_tool_loop(
+            &orchestrator_service,
+            session_id.as_deref(),
+            tenant_id.as_deref(),
+            request_prefix_hash,
+            &requested_model,
+        )
+        .await
+    } else {
+        None
+    };
+
+    let routing_result = match loop_reuse {
+        Some(reuse) => {
+            debug!(
+                model = %reuse.model,
+                "tool-loop continuation — replaying this loop's model instead of re-routing"
+            );
+            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_TOOL_LOOP);
+            Ok(RoutingResult {
+                model_name: reuse.model.clone(),
+                models: vec![reuse.model],
+                route_name: reuse.route_name,
+            })
+        }
+        None => {
+            router_chat_get_upstream_model(
+                Arc::clone(&orchestrator_service),
+                client_request,
+                &request_path,
+                &request_id,
+                inline_routing_preferences,
+            )
+            .await
+        }
+    };
 
     match routing_result {
         Ok(result) => {
@@ -239,6 +277,7 @@ async fn routing_decision_inner(
                     context_tokens,
                     candidate_model: &candidate_model,
                     candidate_route: result.route_name.as_deref(),
+                    requested_model: &requested_model,
                 },
             )
             .await;

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -72,7 +72,7 @@ pub async fn routing_decision(
     span_attributes: &Option<SpanAttributes>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
-    auto_pin_tool_calls: bool,
+    route_on_user_only: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     let request_headers = request.headers().clone();
     let request_id: String = request_headers
@@ -113,7 +113,7 @@ pub async fn routing_decision(
         tenant_id,
         prompt_caching,
         routing_budget,
-        auto_pin_tool_calls,
+        route_on_user_only,
     )
     .instrument(request_span)
     .await
@@ -131,7 +131,7 @@ async fn routing_decision_inner(
     tenant_id: Option<String>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
-    auto_pin_tool_calls: bool,
+    route_on_user_only: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     set_service_name(operation_component::ROUTING);
     let routing_budget =
@@ -209,7 +209,7 @@ async fn routing_decision_inner(
         inline_routing_preferences.is_some() || orchestrator_service.has_routing_preferences();
     let implicit_affinity_enabled = prompt_caching.session_affinity
         || routing_budget.is_some()
-        || (auto_pin_tool_calls && routing_can_override_model);
+        || (route_on_user_only && routing_can_override_model);
     let session_router::SessionResolution {
         request_prefix_hash,
         session_id,
@@ -230,10 +230,10 @@ async fn routing_decision_inner(
         0
     };
 
-    // Mirror the proxy path: opt-in (`routing.auto_pin_tool_calls`) skips the router
+    // Mirror the proxy path: opt-in (`routing.route_on_user_only`) skips the router
     // on non-user tails and replays the prior decision.
     let loop_reuse =
-        if session_router::should_reuse_prior_decision(auto_pin_tool_calls, &request_messages) {
+        if session_router::should_reuse_prior_decision(route_on_user_only, &request_messages) {
             session_router::reuse_prior_decision(
                 &orchestrator_service,
                 session_id.as_deref(),

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -72,6 +72,7 @@ pub async fn routing_decision(
     span_attributes: &Option<SpanAttributes>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
+    route_on_user_turn: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     let request_headers = request.headers().clone();
     let request_id: String = request_headers
@@ -112,6 +113,7 @@ pub async fn routing_decision(
         tenant_id,
         prompt_caching,
         routing_budget,
+        route_on_user_turn,
     )
     .instrument(request_span)
     .await
@@ -129,6 +131,7 @@ async fn routing_decision_inner(
     tenant_id: Option<String>,
     prompt_caching: EffectivePromptCaching,
     routing_budget: Option<EffectiveRoutingBudget>,
+    route_on_user_turn: bool,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     set_service_name(operation_component::ROUTING);
     let routing_budget =
@@ -201,11 +204,12 @@ async fn routing_decision_inner(
     // interoperate across the full-proxy and decision paths.
     // Derive the implicit session key when either prompt-caching affinity or the routing
     // budget is active, so the budget works the same way with caching off — and whenever
-    // routing preferences are in play, so an agentic tool loop can replay its decision.
+    // routing preferences are in play, so a later non-user turn can replay its decision.
     let routing_can_override_model =
         inline_routing_preferences.is_some() || orchestrator_service.has_routing_preferences();
-    let implicit_affinity_enabled =
-        prompt_caching.session_affinity || routing_budget.is_some() || routing_can_override_model;
+    let implicit_affinity_enabled = prompt_caching.session_affinity
+        || routing_budget.is_some()
+        || (route_on_user_turn && routing_can_override_model);
     let session_router::SessionResolution {
         request_prefix_hash,
         session_id,
@@ -226,29 +230,29 @@ async fn routing_decision_inner(
         0
     };
 
-    // Mirror the proxy path: a step of an agentic tool loop replays the decision the loop
-    // already made rather than re-running the router, so callers polling this endpoint
-    // between tool calls get a stable answer for the whole turn.
-    let loop_reuse = if session_router::is_tool_loop_continuation(&request_messages) {
-        session_router::reuse_for_tool_loop(
-            &orchestrator_service,
-            session_id.as_deref(),
-            tenant_id.as_deref(),
-            request_prefix_hash,
-            &requested_model,
-        )
-        .await
-    } else {
-        None
-    };
+    // Mirror the proxy path: opt-in (`routing.route_on_user_turn`) skips the router
+    // on non-user tails and replays the prior decision.
+    let loop_reuse =
+        if session_router::should_reuse_prior_decision(route_on_user_turn, &request_messages) {
+            session_router::reuse_prior_decision(
+                &orchestrator_service,
+                session_id.as_deref(),
+                tenant_id.as_deref(),
+                request_prefix_hash,
+                &requested_model,
+            )
+            .await
+        } else {
+            None
+        };
 
     let routing_result = match loop_reuse {
         Some(reuse) => {
             debug!(
                 model = %reuse.model,
-                "tool-loop continuation — replaying this loop's model instead of re-routing"
+                "not a user turn — replaying the prior model instead of re-routing"
             );
-            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_TOOL_LOOP);
+            bs_metrics::record_routing_skip(metric_labels::ROUTING_SKIP_NOT_USER_TURN);
             Ok(RoutingResult {
                 model_name: reuse.model.clone(),
                 models: vec![reuse.model],

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -360,10 +360,10 @@ async fn init_app_state(
             .as_ref()
             .and_then(|r| r.routing_budget.as_ref()),
     )?;
-    let route_on_user_turn = config
+    let auto_pin_tool_calls = config
         .routing
         .as_ref()
-        .is_some_and(|r| r.route_on_user_turn);
+        .is_some_and(|r| r.auto_pin_tool_calls);
 
     // The routing-budget cost gate needs per-model pricing to compute switch cost.
     if routing_budget.is_some() {
@@ -388,7 +388,7 @@ async fn init_app_state(
     // Without a tenant header, sessions from different customers share one keyspace,
     // so identical prompts from different tenants would collide on the same binding.
     let session_state_in_use =
-        prompt_caching.session_affinity || routing_budget.is_some() || route_on_user_turn;
+        prompt_caching.session_affinity || routing_budget.is_some() || auto_pin_tool_calls;
     if session_state_in_use
         && config
             .routing
@@ -419,7 +419,7 @@ async fn init_app_state(
         signals_enabled,
         prompt_caching,
         routing_budget,
-        route_on_user_turn,
+        auto_pin_tool_calls,
     })
 }
 
@@ -593,7 +593,7 @@ async fn dispatch(
                 &state.span_attributes,
                 state.prompt_caching,
                 state.routing_budget,
-                state.route_on_user_turn,
+                state.auto_pin_tool_calls,
             )
             .with_context(parent_cx)
             .await;

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -360,6 +360,10 @@ async fn init_app_state(
             .as_ref()
             .and_then(|r| r.routing_budget.as_ref()),
     )?;
+    let route_on_user_turn = config
+        .routing
+        .as_ref()
+        .is_some_and(|r| r.route_on_user_turn);
 
     // The routing-budget cost gate needs per-model pricing to compute switch cost.
     if routing_budget.is_some() {
@@ -383,7 +387,8 @@ async fn init_app_state(
     // Session bindings (anchor model, budget spend) are keyed by tenant + session.
     // Without a tenant header, sessions from different customers share one keyspace,
     // so identical prompts from different tenants would collide on the same binding.
-    let session_state_in_use = prompt_caching.session_affinity || routing_budget.is_some();
+    let session_state_in_use =
+        prompt_caching.session_affinity || routing_budget.is_some() || route_on_user_turn;
     if session_state_in_use
         && config
             .routing
@@ -414,6 +419,7 @@ async fn init_app_state(
         signals_enabled,
         prompt_caching,
         routing_budget,
+        route_on_user_turn,
     })
 }
 
@@ -587,6 +593,7 @@ async fn dispatch(
                 &state.span_attributes,
                 state.prompt_caching,
                 state.routing_budget,
+                state.route_on_user_turn,
             )
             .with_context(parent_cx)
             .await;

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -594,6 +594,7 @@ async fn dispatch(
                 state.prompt_caching,
                 state.routing_budget,
                 state.route_on_user_only,
+                &state.model_aliases,
             )
             .with_context(parent_cx)
             .await;

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -360,10 +360,10 @@ async fn init_app_state(
             .as_ref()
             .and_then(|r| r.routing_budget.as_ref()),
     )?;
-    let auto_pin_tool_calls = config
+    let route_on_user_only = config
         .routing
         .as_ref()
-        .is_some_and(|r| r.auto_pin_tool_calls);
+        .is_some_and(|r| r.route_on_user_only);
 
     // The routing-budget cost gate needs per-model pricing to compute switch cost.
     if routing_budget.is_some() {
@@ -388,7 +388,7 @@ async fn init_app_state(
     // Without a tenant header, sessions from different customers share one keyspace,
     // so identical prompts from different tenants would collide on the same binding.
     let session_state_in_use =
-        prompt_caching.session_affinity || routing_budget.is_some() || auto_pin_tool_calls;
+        prompt_caching.session_affinity || routing_budget.is_some() || route_on_user_only;
     if session_state_in_use
         && config
             .routing
@@ -419,7 +419,7 @@ async fn init_app_state(
         signals_enabled,
         prompt_caching,
         routing_budget,
-        auto_pin_tool_calls,
+        route_on_user_only,
     })
 }
 
@@ -593,7 +593,7 @@ async fn dispatch(
                 &state.span_attributes,
                 state.prompt_caching,
                 state.routing_budget,
-                state.auto_pin_tool_calls,
+                state.route_on_user_only,
             )
             .with_context(parent_cx)
             .await;

--- a/crates/brightstaff/src/metrics/labels.rs
+++ b/crates/brightstaff/src/metrics/labels.rs
@@ -68,3 +68,8 @@ pub const SWITCH_REASON_WITHIN_CAP: &str = "within_cap";
 pub const SWITCH_REASON_OVER_CAP: &str = "over_cap";
 /// Pricing was missing for one side, so the switch was allowed without a cost gate.
 pub const SWITCH_REASON_NO_PRICING: &str = "no_pricing";
+
+// Quality-routing skips (brightstaff_router_skips_total).
+/// The request continued an agentic tool loop, so the decision the loop already made was
+/// replayed instead of re-running the router.
+pub const ROUTING_SKIP_TOOL_LOOP: &str = "tool_loop_continuation";

--- a/crates/brightstaff/src/metrics/labels.rs
+++ b/crates/brightstaff/src/metrics/labels.rs
@@ -77,6 +77,6 @@ pub const SWITCH_REASON_OVER_CAP: &str = "over_cap";
 pub const SWITCH_REASON_NO_PRICING: &str = "no_pricing";
 
 // Quality-routing skips (brightstaff_router_skips_total).
-/// The request continued an agentic tool loop, so the decision the loop already made was
-/// replayed instead of re-running the router.
-pub const ROUTING_SKIP_TOOL_LOOP: &str = "tool_loop_continuation";
+/// The last message was not a user turn, so the prior routing decision was replayed
+/// instead of re-running the router.
+pub const ROUTING_SKIP_NOT_USER_TURN: &str = "not_user_turn";

--- a/crates/brightstaff/src/metrics/mod.rs
+++ b/crates/brightstaff/src/metrics/mod.rs
@@ -373,6 +373,15 @@ pub fn record_router_decision(
     .record(duration.as_secs_f64());
 }
 
+/// A request that bypassed quality routing and replayed an existing decision instead.
+pub fn record_routing_skip(reason: &'static str) {
+    counter!(
+        "brightstaff_router_skips_total",
+        "reason" => reason,
+    )
+    .increment(1);
+}
+
 pub fn record_routing_service_outcome(outcome: &'static str) {
     counter!(
         "brightstaff_routing_service_requests_total",

--- a/crates/brightstaff/src/router/orchestrator.rs
+++ b/crates/brightstaff/src/router/orchestrator.rs
@@ -158,6 +158,18 @@ impl OrchestratorService {
         }
     }
 
+    /// Look up a session binding without recording a cache event. For callers that
+    /// inspect a binding ahead of the routing decision that will look it up again, so a
+    /// single request still counts as one hit or miss.
+    pub async fn peek_binding(
+        &self,
+        session_id: &str,
+        tenant_id: Option<&str>,
+    ) -> Option<SessionBinding> {
+        let cache = self.session_cache.as_ref()?;
+        cache.get(&Self::session_key(tenant_id, session_id)).await
+    }
+
     /// Look up a session binding. Warmth is the caller's concern (time since
     /// `last_used`); this only reports whether a binding exists.
     pub async fn get_binding(
@@ -165,13 +177,20 @@ impl OrchestratorService {
         session_id: &str,
         tenant_id: Option<&str>,
     ) -> Option<SessionBinding> {
-        let cache = self.session_cache.as_ref()?;
-        let result = cache.get(&Self::session_key(tenant_id, session_id)).await;
+        self.session_cache.as_ref()?;
+        let result = self.peek_binding(session_id, tenant_id).await;
         bs_metrics::record_session_cache_event(match result {
             Some(_) => metric_labels::SESSION_CACHE_HIT,
             None => metric_labels::SESSION_CACHE_MISS,
         });
         result
+    }
+
+    /// Whether any routing preferences are registered, i.e. whether quality routing can
+    /// send a request to a model other than the one the client asked for.
+    #[must_use]
+    pub fn has_routing_preferences(&self) -> bool {
+        !self.top_level_preferences.is_empty()
     }
 
     /// The GC bound for a session binding: the per-scope override when provided,
@@ -450,6 +469,7 @@ mod tests {
         SessionBinding {
             anchor_model: model.to_string(),
             default_model: model.to_string(),
+            requested_model: model.to_string(),
             route_name: route_name.map(|r| r.to_string()),
             prefix_hash: None,
             last_used: std::time::SystemTime::now(),

--- a/crates/brightstaff/src/session_cache/mod.rs
+++ b/crates/brightstaff/src/session_cache/mod.rs
@@ -33,7 +33,7 @@ pub struct SessionBinding {
     /// before routing overrode it). Agents run several model lanes over one prompt
     /// prefix — Claude Code's main loop plus its `ANTHROPIC_SMALL_FAST_MODEL` side
     /// calls — and those lanes must not inherit each other's routing decision, so the
-    /// tool-loop gate only reuses a binding whose lane matches the current request.
+    /// reuse gate only reuses a binding whose lane matches the current request.
     #[serde(default)]
     pub requested_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/brightstaff/src/session_cache/mod.rs
+++ b/crates/brightstaff/src/session_cache/mod.rs
@@ -29,6 +29,13 @@ pub struct SessionBinding {
     /// episode begins and preserved across its turns.
     #[serde(default)]
     pub default_model: String,
+    /// Model the *client* asked for when this binding was last written (alias-resolved,
+    /// before routing overrode it). Agents run several model lanes over one prompt
+    /// prefix — Claude Code's main loop plus its `ANTHROPIC_SMALL_FAST_MODEL` side
+    /// calls — and those lanes must not inherit each other's routing decision, so the
+    /// tool-loop gate only reuses a binding whose lane matches the current request.
+    #[serde(default)]
+    pub requested_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route_name: Option<String>,
     /// Hash of the stable prompt prefix (system + tools) observed when the binding was

--- a/crates/brightstaff/src/streaming.rs
+++ b/crates/brightstaff/src/streaming.rs
@@ -211,6 +211,8 @@ pub struct SessionUpdateCtx {
     pub anchor_model: String,
     /// The session's never-switch model for this episode — preserved across the refresh.
     pub default_model: String,
+    /// The binding's model lane — preserved across the refresh.
+    pub requested_model: String,
     pub route_name: Option<String>,
     pub prefix_hash: Option<u64>,
     /// Cumulative never-switch baseline from the decision — preserved across the refresh.
@@ -318,6 +320,7 @@ impl ObservableStreamProcessor {
             tenant_id,
             anchor_model,
             default_model,
+            requested_model,
             route_name,
             prefix_hash,
             baseline_usd,
@@ -378,6 +381,7 @@ impl ObservableStreamProcessor {
         let binding = SessionBinding {
             anchor_model,
             default_model,
+            requested_model,
             route_name,
             prefix_hash,
             last_used: SystemTime::now(),

--- a/crates/brightstaff/src/tracing/constants.rs
+++ b/crates/brightstaff/src/tracing/constants.rs
@@ -167,9 +167,9 @@ pub mod plano {
     /// (from the idle gap vs. the provider's cache window).
     pub const CACHE_WARM: &str = "plano.cache.warm";
 
-    /// Why quality routing was skipped for this request (e.g. the request continued an
-    /// agentic tool loop, so the loop's existing decision was replayed). Absent when the
-    /// router ran normally.
+    /// Why quality routing was skipped for this request (e.g. the last message was not
+    /// a user turn, so the prior decision was replayed). Absent when the router ran
+    /// normally.
     pub const ROUTING_SKIPPED: &str = "plano.routing.skipped";
 
     /// How long (ms) since the session was last used — the idle gap warmth is measured

--- a/crates/brightstaff/src/tracing/constants.rs
+++ b/crates/brightstaff/src/tracing/constants.rs
@@ -167,6 +167,11 @@ pub mod plano {
     /// (from the idle gap vs. the provider's cache window).
     pub const CACHE_WARM: &str = "plano.cache.warm";
 
+    /// Why quality routing was skipped for this request (e.g. the request continued an
+    /// agentic tool loop, so the loop's existing decision was replayed). Absent when the
+    /// router ran normally.
+    pub const ROUTING_SKIPPED: &str = "plano.routing.skipped";
+
     /// How long (ms) since the session was last used — the idle gap warmth is measured
     /// against.
     pub const CACHE_IDLE_MS: &str = "plano.cache.idle_ms";

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -41,7 +41,7 @@ pub struct Routing {
     /// When true, the quality router runs only on a trailing user message.
     /// Non-user turns replay the prior decision. Default false.
     #[serde(default)]
-    pub auto_pin_tool_calls: bool,
+    pub route_on_user_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1336,21 +1336,21 @@ cache_read_discount: 0.25
     }
 
     #[test]
-    fn test_auto_pin_tool_calls_absent_is_off() {
+    fn test_route_on_user_only_absent_is_off() {
         let routing: Routing = serde_yaml::from_str("model: gpt-4o").unwrap();
-        assert!(!routing.auto_pin_tool_calls);
+        assert!(!routing.route_on_user_only);
     }
 
     #[test]
-    fn test_auto_pin_tool_calls_true_enables() {
-        let routing: Routing = serde_yaml::from_str("auto_pin_tool_calls: true").unwrap();
-        assert!(routing.auto_pin_tool_calls);
+    fn test_route_on_user_only_true_enables() {
+        let routing: Routing = serde_yaml::from_str("route_on_user_only: true").unwrap();
+        assert!(routing.route_on_user_only);
     }
 
     #[test]
-    fn test_auto_pin_tool_calls_false_is_off() {
-        let routing: Routing = serde_yaml::from_str("auto_pin_tool_calls: false").unwrap();
-        assert!(!routing.auto_pin_tool_calls);
+    fn test_route_on_user_only_false_is_off() {
+        let routing: Routing = serde_yaml::from_str("route_on_user_only: false").unwrap();
+        assert!(!routing.route_on_user_only);
     }
 
     #[test]

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -41,7 +41,7 @@ pub struct Routing {
     /// When true, the quality router runs only on a trailing user message.
     /// Non-user turns replay the prior decision. Default false.
     #[serde(default)]
-    pub route_on_user_turn: bool,
+    pub auto_pin_tool_calls: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1336,21 +1336,21 @@ cache_read_discount: 0.25
     }
 
     #[test]
-    fn test_route_on_user_turn_absent_is_off() {
+    fn test_auto_pin_tool_calls_absent_is_off() {
         let routing: Routing = serde_yaml::from_str("model: gpt-4o").unwrap();
-        assert!(!routing.route_on_user_turn);
+        assert!(!routing.auto_pin_tool_calls);
     }
 
     #[test]
-    fn test_route_on_user_turn_true_enables() {
-        let routing: Routing = serde_yaml::from_str("route_on_user_turn: true").unwrap();
-        assert!(routing.route_on_user_turn);
+    fn test_auto_pin_tool_calls_true_enables() {
+        let routing: Routing = serde_yaml::from_str("auto_pin_tool_calls: true").unwrap();
+        assert!(routing.auto_pin_tool_calls);
     }
 
     #[test]
-    fn test_route_on_user_turn_false_is_off() {
-        let routing: Routing = serde_yaml::from_str("route_on_user_turn: false").unwrap();
-        assert!(!routing.route_on_user_turn);
+    fn test_auto_pin_tool_calls_false_is_off() {
+        let routing: Routing = serde_yaml::from_str("auto_pin_tool_calls: false").unwrap();
+        assert!(!routing.auto_pin_tool_calls);
     }
 
     #[test]

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -38,6 +38,10 @@ pub struct Routing {
     /// derived on its own, and warm anchors are always priced at cached rates —
     /// `prompt_caching` only controls marker injection and affinity-without-budget.
     pub routing_budget: Option<RoutingBudget>,
+    /// When true, the quality router runs only on a trailing user message.
+    /// Non-user turns replay the prior decision. Default false.
+    #[serde(default)]
+    pub route_on_user_turn: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -932,7 +936,8 @@ mod test {
 
     use super::{
         EffectivePromptCaching, EffectiveRoutingBudget, IntoModels, LlmProvider, LlmProviderType,
-        PromptCaching, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT, DEFAULT_MIN_PREFIX_TOKENS,
+        PromptCaching, Routing, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT,
+        DEFAULT_MIN_PREFIX_TOKENS,
     };
     use crate::api::open_ai::ToolType;
 
@@ -1328,6 +1333,24 @@ cache_read_discount: 0.25
     fn test_routing_budget_absent_is_off() {
         // No block configured → gate is off.
         assert!(EffectiveRoutingBudget::from_config(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_route_on_user_turn_absent_is_off() {
+        let routing: Routing = serde_yaml::from_str("model: gpt-4o").unwrap();
+        assert!(!routing.route_on_user_turn);
+    }
+
+    #[test]
+    fn test_route_on_user_turn_true_enables() {
+        let routing: Routing = serde_yaml::from_str("route_on_user_turn: true").unwrap();
+        assert!(routing.route_on_user_turn);
+    }
+
+    #[test]
+    fn test_route_on_user_turn_false_is_off() {
+        let routing: Routing = serde_yaml::from_str("route_on_user_turn: false").unwrap();
+        assert!(!routing.route_on_user_turn);
     }
 
     #[test]

--- a/crates/hermesllm/src/apis/amazon_bedrock.rs
+++ b/crates/hermesllm/src/apis/amazon_bedrock.rs
@@ -234,35 +234,13 @@ impl ProviderRequest for ConverseRequest {
             }
         }
 
-        // Convert conversation messages
+        // Convert conversation messages. Tool use and tool result blocks are split out
+        // into their own OpenAI messages, so callers see the full tool history.
         if let Some(messages) = &self.messages {
             for msg in messages {
-                let role = match msg.role {
-                    ConversationRole::User => Role::User,
-                    ConversationRole::Assistant => Role::Assistant,
-                };
-
-                // Extract text from content blocks
-                let content = msg
-                    .content
-                    .iter()
-                    .filter_map(|block| {
-                        if let ContentBlock::Text { text } = block {
-                            Some(text.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                openai_messages.push(Message {
-                    role,
-                    content: Some(MessageContent::Text(content)),
-                    name: None,
-                    tool_calls: None,
-                    tool_call_id: None,
-                });
+                if let Ok(converted) = TryInto::<Vec<Message>>::try_into(msg.clone()) {
+                    openai_messages.extend(converted);
+                }
             }
         }
 
@@ -271,36 +249,26 @@ impl ProviderRequest for ConverseRequest {
 
     fn set_messages(&mut self, messages: &[crate::apis::openai::Message]) {
         // Convert OpenAI messages to Bedrock format
-        use crate::apis::amazon_bedrock::{ContentBlock, ConversationRole, SystemContentBlock};
+        use crate::apis::amazon_bedrock::SystemContentBlock;
+        use crate::transforms::lib::ExtractText;
 
         let mut system_blocks = Vec::new();
         let mut bedrock_messages = Vec::new();
 
         for msg in messages {
             match msg.role {
-                crate::apis::openai::Role::System => {
-                    if let Some(crate::apis::openai::MessageContent::Text(text)) = &msg.content {
-                        system_blocks.push(SystemContentBlock::Text { text: text.clone() });
+                crate::apis::openai::Role::System | crate::apis::openai::Role::Developer => {
+                    system_blocks.push(SystemContentBlock::Text {
+                        text: msg.content.extract_text(),
+                    });
+                }
+                _ => {
+                    if let Ok(bedrock_message) =
+                        crate::apis::amazon_bedrock::Message::try_from(msg.clone())
+                    {
+                        bedrock_messages.push(bedrock_message);
                     }
                 }
-                crate::apis::openai::Role::User | crate::apis::openai::Role::Assistant => {
-                    let role = match msg.role {
-                        crate::apis::openai::Role::User => ConversationRole::User,
-                        crate::apis::openai::Role::Assistant => ConversationRole::Assistant,
-                        _ => continue,
-                    };
-
-                    let content = if let Some(crate::apis::openai::MessageContent::Text(text)) =
-                        &msg.content
-                    {
-                        vec![ContentBlock::Text { text: text.clone() }]
-                    } else {
-                        vec![]
-                    };
-
-                    bedrock_messages.push(crate::apis::amazon_bedrock::Message { role, content });
-                }
-                _ => {}
             }
         }
 
@@ -1236,5 +1204,117 @@ mod tests {
 
         let tool_spec = serialized.get("tool").unwrap();
         assert_eq!(tool_spec.get("name").unwrap(), "get_weather");
+    }
+
+    #[test]
+    fn test_get_messages_exposes_tool_use_and_tool_result() {
+        use crate::apis::openai::Role as OpenAIRole;
+
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet".to_string(),
+            system: Some(vec![SystemContentBlock::Text {
+                text: "You are helpful".to_string(),
+            }]),
+            messages: Some(vec![
+                Message {
+                    role: ConversationRole::User,
+                    content: vec![ContentBlock::Text {
+                        text: "weather in Seattle?".to_string(),
+                    }],
+                },
+                Message {
+                    role: ConversationRole::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        tool_use: ToolUseBlock {
+                            tool_use_id: "call_1".to_string(),
+                            name: "get_weather".to_string(),
+                            input: json!({"city": "Seattle"}),
+                        },
+                    }],
+                },
+                Message {
+                    role: ConversationRole::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_result: ToolResultBlock {
+                            tool_use_id: "call_1".to_string(),
+                            content: vec![ToolResultContentBlock::Text {
+                                text: "72F".to_string(),
+                            }],
+                            status: Some(ToolResultStatus::Success),
+                        },
+                    }],
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let messages = request.get_messages();
+
+        let roles: Vec<_> = messages.iter().map(|m| m.role.clone()).collect();
+        assert_eq!(
+            roles,
+            vec![
+                OpenAIRole::System,
+                OpenAIRole::User,
+                OpenAIRole::Assistant,
+                OpenAIRole::Tool,
+            ]
+        );
+        assert_eq!(
+            messages[2].tool_calls.as_ref().unwrap()[0].function.name,
+            "get_weather"
+        );
+        assert_eq!(messages[3].tool_call_id, Some("call_1".to_string()));
+    }
+
+    #[test]
+    fn test_get_messages_set_messages_round_trip_keeps_tools() {
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet".to_string(),
+            system: Some(vec![SystemContentBlock::Text {
+                text: "You are helpful".to_string(),
+            }]),
+            messages: Some(vec![
+                Message {
+                    role: ConversationRole::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        tool_use: ToolUseBlock {
+                            tool_use_id: "call_1".to_string(),
+                            name: "get_weather".to_string(),
+                            input: json!({"city": "Seattle"}),
+                        },
+                    }],
+                },
+                Message {
+                    role: ConversationRole::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_result: ToolResultBlock {
+                            tool_use_id: "call_1".to_string(),
+                            content: vec![ToolResultContentBlock::Text {
+                                text: "72F".to_string(),
+                            }],
+                            status: Some(ToolResultStatus::Success),
+                        },
+                    }],
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let messages = request.get_messages();
+        let mut round_tripped = request.clone();
+        round_tripped.set_messages(&messages);
+
+        let bedrock_messages = round_tripped.messages.unwrap();
+        assert_eq!(bedrock_messages.len(), 2);
+        assert!(matches!(
+            bedrock_messages[0].content[0],
+            ContentBlock::ToolUse { .. }
+        ));
+        assert!(matches!(
+            bedrock_messages[1].content[0],
+            ContentBlock::ToolResult { .. }
+        ));
+        assert_eq!(round_tripped.system.unwrap().len(), 1);
     }
 }

--- a/crates/hermesllm/src/apis/openai_responses.rs
+++ b/crates/hermesllm/src/apis/openai_responses.rs
@@ -285,6 +285,11 @@ pub struct ConversationParam {
 }
 
 /// Tool definitions
+///
+/// Absent optionals must be omitted rather than emitted as `null`: the Responses
+/// upstream path re-serializes the parsed request, and providers reject a null for a
+/// parameter they do not define (e.g. `web_search` has no `domains`).
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Tool {
@@ -318,6 +323,38 @@ pub enum Tool {
         display_number: Option<i32>,
     },
     /// Custom tool (provider/SDK-specific tool contract)
+    Custom {
+        name: Option<String>,
+        description: Option<String>,
+        format: Option<serde_json::Value>,
+    },
+    /// Group of related tools addressed under a shared name, e.g. `crm` or `billing`.
+    /// Codex sends one of these per tool namespace, so it is on the default path for
+    /// every Codex session rather than an opt-in feature.
+    Namespace {
+        name: String,
+        description: String,
+        tools: Vec<NamespaceTool>,
+    },
+}
+
+/// Member of a [`Tool::Namespace`]. The spec restricts group members to function and
+/// custom tools — nested namespaces and hosted tools are not permitted — so this is a
+/// separate enum rather than a recursive `Tool`, which would accept both.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NamespaceTool {
+    Function {
+        name: String,
+        description: Option<String>,
+        parameters: Option<serde_json::Value>,
+        strict: Option<bool>,
+        /// Withholds the schema until the model selects the namespace. Preserved because
+        /// dropping it would silently pull deferred tools into the initial prompt.
+        defer_loading: Option<bool>,
+        output_schema: Option<serde_json::Value>,
+    },
     Custom {
         name: Option<String>,
         description: Option<String>,
@@ -1454,6 +1491,139 @@ impl crate::providers::streaming_response::ProviderStreamResponse for ResponsesA
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Codex sends namespaced tool groups on every session, so rejecting this shape
+    /// blocks the client outright rather than degrading one feature.
+    #[test]
+    fn test_namespace_tool_deserializes_with_function_and_custom_members() {
+        let json = r#"{
+            "type": "namespace",
+            "name": "crm",
+            "description": "CRM tools for customer lookup.",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_customer_profile",
+                    "description": "Fetch a customer profile by ID.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": { "customer_id": { "type": "string" } },
+                        "required": ["customer_id"]
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "list_open_orders",
+                    "defer_loading": true,
+                    "parameters": { "type": "object", "properties": {} }
+                },
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "Apply a patch."
+                }
+            ]
+        }"#;
+
+        let tool: Tool = serde_json::from_str(json).expect("namespace tool should deserialize");
+        match tool {
+            Tool::Namespace {
+                name,
+                description,
+                tools,
+            } => {
+                assert_eq!(name, "crm");
+                assert_eq!(description, "CRM tools for customer lookup.");
+                assert_eq!(tools.len(), 3);
+                match &tools[1] {
+                    NamespaceTool::Function {
+                        name,
+                        defer_loading,
+                        ..
+                    } => {
+                        assert_eq!(name, "list_open_orders");
+                        assert_eq!(*defer_loading, Some(true));
+                    }
+                    other => panic!("expected deferred function member, got {other:?}"),
+                }
+                assert!(matches!(tools[2], NamespaceTool::Custom { .. }));
+            }
+            other => panic!("expected namespace tool, got {other:?}"),
+        }
+    }
+
+    /// Responses-to-Responses is a passthrough that re-serializes the parsed request,
+    /// so anything dropped here is silently dropped on the wire to the provider.
+    #[test]
+    fn test_namespace_tool_round_trips_without_losing_fields() {
+        let original = json!({
+            "type": "namespace",
+            "name": "crm",
+            "description": "CRM tools.",
+            "tools": [{
+                "type": "function",
+                "name": "list_open_orders",
+                "description": "List open orders.",
+                "parameters": { "type": "object", "properties": {} },
+                "strict": true,
+                "defer_loading": true,
+                "output_schema": { "type": "object" }
+            }]
+        });
+
+        let tool: Tool = serde_json::from_value(original.clone()).expect("should deserialize");
+        let reserialized = serde_json::to_value(&tool).expect("should serialize");
+        assert_eq!(reserialized, original);
+    }
+
+    /// Guards the actual passthrough path: parse a client body, then serialize it the
+    /// way the upstream request is built.
+    #[test]
+    fn test_web_search_tool_survives_full_request_round_trip_without_extra_keys() {
+        let body = br#"{"model":"gpt-5.3-codex","input":"hi","tools":[{"type":"web_search"}]}"#;
+        let request = ResponsesAPIRequest::try_from(&body[..]).expect("should parse");
+        let bytes = request.to_bytes().expect("should serialize");
+        let value: serde_json::Value = serde_json::from_slice(&bytes).expect("valid json");
+        let tool = &value["tools"][0];
+        assert_eq!(tool["type"], "web_search");
+        assert!(
+            tool.get("domains").is_none(),
+            "web_search must not carry a `domains` key upstream, got: {tool}"
+        );
+    }
+
+    /// Providers reject an explicit null for a parameter they do not define, so absent
+    /// optionals must not survive the parse/re-serialize round trip on the passthrough.
+    #[test]
+    fn test_tool_omits_absent_optionals_instead_of_emitting_null() {
+        let tool: Tool = serde_json::from_str(r#"{"type":"web_search"}"#).expect("should parse");
+        let reserialized = serde_json::to_value(&tool).expect("should serialize");
+        assert_eq!(reserialized, json!({ "type": "web_search" }));
+
+        let function: Tool =
+            serde_json::from_str(r#"{"type":"function","name":"noop"}"#).expect("should parse");
+        let reserialized = serde_json::to_value(&function).expect("should serialize");
+        assert_eq!(reserialized, json!({ "type": "function", "name": "noop" }));
+    }
+
+    /// Strict translation: the group may only contain function and custom tools, so a
+    /// nested namespace has to be rejected rather than quietly dropped.
+    #[test]
+    fn test_namespace_tool_rejects_nested_namespace_member() {
+        let json = r#"{
+            "type": "namespace",
+            "name": "outer",
+            "description": "Outer group.",
+            "tools": [{
+                "type": "namespace",
+                "name": "inner",
+                "description": "Inner group.",
+                "tools": []
+            }]
+        }"#;
+
+        assert!(serde_json::from_str::<Tool>(json).is_err());
+    }
 
     /// Task C guard: a reasoning output item deserializes WITHOUT a `summary`
     /// field (now `#[serde(default)]`) and WITH optional `content`,

--- a/crates/hermesllm/src/apis/openai_responses.rs
+++ b/crates/hermesllm/src/apis/openai_responses.rs
@@ -120,33 +120,201 @@ pub enum InputParam {
     SingleItem(InputItem),
 }
 
-/// Input item - can be a message, item reference, function call output, etc.
+/// Input item. Typed items are dispatched on the `type` discriminator so a
+/// coincidental `id` field cannot steal `function_call` / `function_call_output`
+/// into [`InputItem::ItemReference`]. Easy-input messages (`{role, content}`
+/// with no `type`) fall through to [`InputItem::Message`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(from = "InputItemWire", into = "InputItemWire")]
 pub enum InputItem {
-    /// Input message (role + content)
+    /// Input message (role + content). Covers both easy-input (no `type`) and
+    /// `{ "type": "message", ... }`.
     Message(InputMessage),
-    /// Item reference
-    ItemReference {
-        #[serde(rename = "type")]
-        item_type: String,
-        id: String,
-    },
-    /// Function call emitted by model in prior turn
+    /// Item reference (`type: item_reference`)
+    ItemReference { id: String },
+    /// Function call emitted by the model in a prior turn
     FunctionCall {
-        #[serde(rename = "type")]
-        item_type: String,
         name: String,
         arguments: String,
         call_id: String,
+        id: Option<String>,
+        status: Option<String>,
     },
     /// Function call output
     FunctionCallOutput {
-        #[serde(rename = "type")]
-        item_type: String,
         call_id: String,
         output: serde_json::Value,
+        id: Option<String>,
+        status: Option<String>,
     },
+    /// Reasoning item from a prior turn. Not converted to Chat Completions.
+    Reasoning {
+        id: Option<String>,
+        summary: Vec<serde_json::Value>,
+        content: Vec<serde_json::Value>,
+        encrypted_content: Option<String>,
+        status: Option<String>,
+    },
+    /// Any other typed item (`custom_tool_call`, `computer_call`, …). The
+    /// original JSON is kept so Responses→Responses round-trips don't drop it.
+    Ignored(serde_json::Value),
+}
+
+/// Wire form: try internally-tagged known types first, then untyped messages,
+/// then preserve unknown typed items as raw JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum InputItemWire {
+    Typed(TypedInputItem),
+    Message(InputMessage),
+    Ignored(serde_json::Value),
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TypedInputItem {
+    Message {
+        role: MessageRole,
+        content: MessageContent,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+    FunctionCall {
+        name: String,
+        arguments: String,
+        call_id: String,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+    FunctionCallOutput {
+        call_id: String,
+        output: serde_json::Value,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+    ItemReference {
+        id: String,
+    },
+    Reasoning {
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        summary: Vec<serde_json::Value>,
+        #[serde(default)]
+        content: Vec<serde_json::Value>,
+        #[serde(default)]
+        encrypted_content: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+}
+
+impl From<InputItemWire> for InputItem {
+    fn from(wire: InputItemWire) -> Self {
+        match wire {
+            InputItemWire::Message(message) => InputItem::Message(message),
+            InputItemWire::Ignored(value) => InputItem::Ignored(value),
+            InputItemWire::Typed(TypedInputItem::Message { role, content, .. }) => {
+                InputItem::Message(InputMessage { role, content })
+            }
+            InputItemWire::Typed(TypedInputItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+                id,
+                status,
+            }) => InputItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+                id,
+                status,
+            },
+            InputItemWire::Typed(TypedInputItem::FunctionCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            }) => InputItem::FunctionCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            },
+            InputItemWire::Typed(TypedInputItem::ItemReference { id }) => {
+                InputItem::ItemReference { id }
+            }
+            InputItemWire::Typed(TypedInputItem::Reasoning {
+                id,
+                summary,
+                content,
+                encrypted_content,
+                status,
+            }) => InputItem::Reasoning {
+                id,
+                summary,
+                content,
+                encrypted_content,
+                status,
+            },
+        }
+    }
+}
+
+impl From<InputItem> for InputItemWire {
+    fn from(item: InputItem) -> Self {
+        match item {
+            InputItem::Message(message) => InputItemWire::Message(message),
+            InputItem::Ignored(value) => InputItemWire::Ignored(value),
+            InputItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+                id,
+                status,
+            } => InputItemWire::Typed(TypedInputItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+                id,
+                status,
+            }),
+            InputItem::FunctionCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            } => InputItemWire::Typed(TypedInputItem::FunctionCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            }),
+            InputItem::ItemReference { id } => {
+                InputItemWire::Typed(TypedInputItem::ItemReference { id })
+            }
+            InputItem::Reasoning {
+                id,
+                summary,
+                content,
+                encrypted_content,
+                status,
+            } => InputItemWire::Typed(TypedInputItem::Reasoning {
+                id,
+                summary,
+                content,
+                encrypted_content,
+                status,
+            }),
+        }
+    }
 }
 
 /// Input message with role and content
@@ -1675,6 +1843,87 @@ mod tests {
             }
             _ => panic!("Expected OutputItem::Reasoning"),
         }
+    }
+
+    /// `type` is authoritative: a function_call that also carries `id` must not
+    /// be swallowed by ItemReference (the old untagged `{type, id}` variant).
+    #[test]
+    fn test_input_item_function_call_with_id_is_not_item_reference() {
+        let json = r#"{
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "exec_command",
+            "arguments": "{\"cmd\":\"pwd\"}",
+            "status": "completed"
+        }"#;
+        let item: InputItem = serde_json::from_str(json).expect("should parse");
+        match item {
+            InputItem::FunctionCall {
+                name,
+                call_id,
+                id,
+                status,
+                ..
+            } => {
+                assert_eq!(name, "exec_command");
+                assert_eq!(call_id, "call_1");
+                assert_eq!(id.as_deref(), Some("fc_1"));
+                assert_eq!(status.as_deref(), Some("completed"));
+            }
+            other => panic!("expected FunctionCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_input_item_function_call_output_with_id_is_not_item_reference() {
+        let json = r#"{
+            "type": "function_call_output",
+            "id": "fc_out_1",
+            "call_id": "call_1",
+            "output": "ok"
+        }"#;
+        let item: InputItem = serde_json::from_str(json).expect("should parse");
+        match item {
+            InputItem::FunctionCallOutput { call_id, id, .. } => {
+                assert_eq!(call_id, "call_1");
+                assert_eq!(id.as_deref(), Some("fc_out_1"));
+            }
+            other => panic!("expected FunctionCallOutput, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_input_item_reasoning_deserializes() {
+        let json = r#"{"type":"reasoning","id":"rs_1","summary":[]}"#;
+        let item: InputItem = serde_json::from_str(json).expect("should parse");
+        match item {
+            InputItem::Reasoning { id, .. } => assert_eq!(id.as_deref(), Some("rs_1")),
+            other => panic!("expected Reasoning, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_input_item_unknown_type_is_preserved() {
+        let json = serde_json::json!({
+            "type": "custom_tool_call",
+            "id": "ctc_1",
+            "call_id": "call_9",
+            "name": "browser.open"
+        });
+        let item: InputItem = serde_json::from_value(json.clone()).expect("should parse");
+        match &item {
+            InputItem::Ignored(value) => assert_eq!(value["type"], "custom_tool_call"),
+            other => panic!("expected Ignored, got {:?}", other),
+        }
+        assert_eq!(serde_json::to_value(&item).unwrap(), json);
+    }
+
+    #[test]
+    fn test_input_item_easy_message_without_type() {
+        let json = r#"{"role":"user","content":"hello"}"#;
+        let item: InputItem = serde_json::from_str(json).expect("should parse");
+        assert!(matches!(item, InputItem::Message(_)));
     }
 
     /// Task C guard: output text delta/done deserialize with `logprobs` omitted

--- a/crates/hermesllm/src/apis/openai_responses.rs
+++ b/crates/hermesllm/src/apis/openai_responses.rs
@@ -147,6 +147,23 @@ pub enum InputItem {
         id: Option<String>,
         status: Option<String>,
     },
+    /// Custom tool call emitted by the model in a prior turn. Unlike a function call
+    /// the payload is free-form text rather than JSON arguments. Codex registers custom
+    /// tools by default, so its continuations carry these instead of `function_call`.
+    CustomToolCall {
+        name: String,
+        input: String,
+        call_id: String,
+        id: Option<String>,
+        status: Option<String>,
+    },
+    /// Custom tool call output, paired to its call by `call_id`.
+    CustomToolCallOutput {
+        call_id: String,
+        output: serde_json::Value,
+        id: Option<String>,
+        status: Option<String>,
+    },
     /// Reasoning item from a prior turn. Not converted to Chat Completions.
     Reasoning {
         id: Option<String>,
@@ -155,8 +172,8 @@ pub enum InputItem {
         encrypted_content: Option<String>,
         status: Option<String>,
     },
-    /// Any other typed item (`custom_tool_call`, `computer_call`, …). The
-    /// original JSON is kept so Responses→Responses round-trips don't drop it.
+    /// Any other typed item (`computer_call`, `local_shell_call`, …). The original
+    /// JSON is kept so Responses→Responses round-trips don't drop it.
     Ignored(serde_json::Value),
 }
 
@@ -192,6 +209,23 @@ enum TypedInputItem {
         status: Option<String>,
     },
     FunctionCallOutput {
+        call_id: String,
+        output: serde_json::Value,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+    CustomToolCall {
+        name: String,
+        input: String,
+        call_id: String,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+    },
+    CustomToolCallOutput {
         call_id: String,
         output: serde_json::Value,
         #[serde(default)]
@@ -248,6 +282,30 @@ impl From<InputItemWire> for InputItem {
                 id,
                 status,
             },
+            InputItemWire::Typed(TypedInputItem::CustomToolCall {
+                name,
+                input,
+                call_id,
+                id,
+                status,
+            }) => InputItem::CustomToolCall {
+                name,
+                input,
+                call_id,
+                id,
+                status,
+            },
+            InputItemWire::Typed(TypedInputItem::CustomToolCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            }) => InputItem::CustomToolCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            },
             InputItemWire::Typed(TypedInputItem::ItemReference { id }) => {
                 InputItem::ItemReference { id }
             }
@@ -292,6 +350,30 @@ impl From<InputItem> for InputItemWire {
                 id,
                 status,
             } => InputItemWire::Typed(TypedInputItem::FunctionCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            }),
+            InputItem::CustomToolCall {
+                name,
+                input,
+                call_id,
+                id,
+                status,
+            } => InputItemWire::Typed(TypedInputItem::CustomToolCall {
+                name,
+                input,
+                call_id,
+                id,
+                status,
+            }),
+            InputItem::CustomToolCallOutput {
+                call_id,
+                output,
+                id,
+                status,
+            } => InputItemWire::Typed(TypedInputItem::CustomToolCallOutput {
                 call_id,
                 output,
                 id,
@@ -1906,16 +1988,80 @@ mod tests {
     #[test]
     fn test_input_item_unknown_type_is_preserved() {
         let json = serde_json::json!({
-            "type": "custom_tool_call",
-            "id": "ctc_1",
+            "type": "computer_call",
+            "id": "cc_1",
             "call_id": "call_9",
-            "name": "browser.open"
+            "action": {"type": "screenshot"}
         });
         let item: InputItem = serde_json::from_value(json.clone()).expect("should parse");
         match &item {
-            InputItem::Ignored(value) => assert_eq!(value["type"], "custom_tool_call"),
+            InputItem::Ignored(value) => assert_eq!(value["type"], "computer_call"),
             other => panic!("expected Ignored, got {:?}", other),
         }
+        assert_eq!(serde_json::to_value(&item).unwrap(), json);
+    }
+
+    /// Codex's default tool contract. These must be typed, not `Ignored`, or a
+    /// custom-tool continuation normalizes to a trailing user message.
+    #[test]
+    fn test_input_item_custom_tool_call_round_trips() {
+        let json = serde_json::json!({
+            "type": "custom_tool_call",
+            "id": "ctc_1",
+            "call_id": "call_9",
+            "name": "shell",
+            "input": "cat main.rs"
+        });
+        let item: InputItem = serde_json::from_value(json.clone()).expect("should parse");
+        match &item {
+            InputItem::CustomToolCall {
+                name,
+                input,
+                call_id,
+                id,
+                ..
+            } => {
+                assert_eq!(name, "shell");
+                assert_eq!(input, "cat main.rs");
+                assert_eq!(call_id, "call_9");
+                assert_eq!(id.as_deref(), Some("ctc_1"));
+            }
+            other => panic!("expected CustomToolCall, got {:?}", other),
+        }
+        assert_eq!(serde_json::to_value(&item).unwrap(), json);
+    }
+
+    #[test]
+    fn test_input_item_custom_tool_call_output_round_trips() {
+        let json = serde_json::json!({
+            "type": "custom_tool_call_output",
+            "call_id": "call_9",
+            "output": "fn main() {}"
+        });
+        let item: InputItem = serde_json::from_value(json.clone()).expect("should parse");
+        match &item {
+            InputItem::CustomToolCallOutput {
+                call_id, output, ..
+            } => {
+                assert_eq!(call_id, "call_9");
+                assert_eq!(output, "fn main() {}");
+            }
+            other => panic!("expected CustomToolCallOutput, got {:?}", other),
+        }
+        assert_eq!(serde_json::to_value(&item).unwrap(), json);
+    }
+
+    /// A malformed custom tool call (no `input`) must not be silently reshaped; it
+    /// degrades to a preserved raw item instead.
+    #[test]
+    fn test_input_item_custom_tool_call_without_input_is_preserved() {
+        let json = serde_json::json!({
+            "type": "custom_tool_call",
+            "call_id": "call_9",
+            "name": "shell"
+        });
+        let item: InputItem = serde_json::from_value(json.clone()).expect("should parse");
+        assert!(matches!(item, InputItem::Ignored(_)));
         assert_eq!(serde_json::to_value(&item).unwrap(), json);
     }
 

--- a/crates/hermesllm/src/apis/openai_responses.rs
+++ b/crates/hermesllm/src/apis/openai_responses.rs
@@ -239,9 +239,12 @@ enum TypedInputItem {
     Reasoning {
         #[serde(default)]
         id: Option<String>,
-        #[serde(default)]
+        // Absent arrays must not come back as `[]`: a reasoning item is opaque provider
+        // state that the Responses passthrough re-serializes verbatim, so adding keys the
+        // client never sent can invalidate it. Mirrors `OutputItem::Reasoning`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         summary: Vec<serde_json::Value>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         content: Vec<serde_json::Value>,
         #[serde(default)]
         encrypted_content: Option<String>,
@@ -1983,6 +1986,43 @@ mod tests {
             InputItem::Reasoning { id, .. } => assert_eq!(id.as_deref(), Some("rs_1")),
             other => panic!("expected Reasoning, got {:?}", other),
         }
+    }
+
+    /// A reasoning item is opaque provider state that the Responses passthrough
+    /// re-serializes verbatim, so absent `summary` / `content` must stay absent rather
+    /// than reappear as `[]`.
+    #[test]
+    fn test_input_item_reasoning_does_not_invent_absent_arrays() {
+        for original in [
+            serde_json::json!({"type": "reasoning", "id": "rs_min"}),
+            serde_json::json!({
+                "type": "reasoning",
+                "id": "rs_1",
+                "encrypted_content": "XYZ",
+                "status": "completed"
+            }),
+            // Present-but-empty arrays are dropped too; the client sent no information
+            // by including them, and the passthrough should not re-assert it.
+            serde_json::json!({"type": "reasoning", "id": "rs_2", "summary": []}),
+        ] {
+            let item: InputItem = serde_json::from_value(original.clone()).expect("should parse");
+            let reserialized = serde_json::to_value(&item).expect("should serialize");
+            for key in ["summary", "content"] {
+                assert!(
+                    reserialized.get(key).is_none(),
+                    "{key} must not be emitted for {original}, got: {reserialized}"
+                );
+            }
+        }
+
+        // A populated array still round-trips.
+        let populated = serde_json::json!({
+            "type": "reasoning",
+            "id": "rs_3",
+            "summary": [{"type": "summary_text", "text": "thinking"}]
+        });
+        let item: InputItem = serde_json::from_value(populated.clone()).expect("should parse");
+        assert_eq!(serde_json::to_value(&item).unwrap(), populated);
     }
 
     #[test]

--- a/crates/hermesllm/src/apis/streaming_shapes/responses_api_streaming_buffer.rs
+++ b/crates/hermesllm/src/apis/streaming_shapes/responses_api_streaming_buffer.rs
@@ -279,7 +279,6 @@ impl ResponsesAPIStreamBuffer {
                         .unwrap()
                         .as_secs() as i64,
                 );
-                self.model = Some("unknown".to_string());
             }
             events.push(self.create_response_created_event());
             self.created_emitted = true;
@@ -451,6 +450,24 @@ impl SseStreamBufferTrait for ResponsesAPIStreamBuffer {
             return;
         }
 
+        // Capture the served model from the raw upstream chunk before the
+        // transform to Responses events drops it. Chat Completions carries it
+        // top-level, Anthropic nests it under `message`. Upstreams that speak
+        // Responses natively are handled below via response.created metadata.
+        if self.model.is_none() {
+            if let Some(data) = &event.data {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                    if let Some(model) = json
+                        .get("model")
+                        .or_else(|| json.pointer("/message/model"))
+                        .and_then(|m| m.as_str())
+                    {
+                        self.model = Some(model.to_string());
+                    }
+                }
+            }
+        }
+
         // Handle [DONE] marker - trigger finalization
         if event.is_done() {
             self.finalize();
@@ -515,7 +532,6 @@ impl SseStreamBufferTrait for ResponsesAPIStreamBuffer {
                         .unwrap()
                         .as_secs() as i64,
                 );
-                self.model = Some("unknown".to_string()); // Will be set by caller if available
             }
 
             events.push(self.create_response_created_event());
@@ -851,6 +867,86 @@ data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890
         assert_eq!(
             completed_count, 1,
             "response.completed should be emitted exactly once"
+        );
+    }
+
+    /// Cross-API streams synthesize their own lifecycle events, so the served
+    /// model has to be recovered from the upstream chunks. Regression test for
+    /// `"model": "unknown"` leaking to Responses clients such as Codex.
+    #[test]
+    fn test_streaming_echoes_upstream_model_in_lifecycle_events() {
+        let raw_input = r#"data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"openai-gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"openai-gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]"#;
+
+        let client_api = SupportedAPIsFromClient::OpenAIResponsesAPI(OpenAIApi::Responses);
+        let upstream_api = SupportedUpstreamAPIs::OpenAIChatCompletions(OpenAIApi::ChatCompletions);
+
+        let stream_iter = SseStreamIter::try_from(raw_input.as_bytes()).unwrap();
+        let mut buffer = ResponsesAPIStreamBuffer::new();
+
+        for raw_event in stream_iter {
+            let transformed_event =
+                SseEvent::try_from((raw_event, &client_api, &upstream_api)).unwrap();
+            buffer.add_transformed_event(transformed_event);
+        }
+
+        let output = String::from_utf8_lossy(&buffer.to_bytes()).to_string();
+
+        assert!(
+            !output.contains(r#""model":"unknown""#),
+            "no lifecycle event should report an unknown model, got:\n{}",
+            output
+        );
+        for event in [
+            "response.created",
+            "response.in_progress",
+            "response.completed",
+        ] {
+            let payload = output
+                .split("event: ")
+                .find(|block| block.starts_with(event))
+                .unwrap_or_else(|| panic!("missing {} in:\n{}", event, output));
+            assert!(
+                payload.contains(r#""model":"openai-gpt-5.4""#),
+                "{} should echo the served model, got:\n{}",
+                event,
+                payload
+            );
+        }
+
+        assert_eq!(
+            buffer
+                .get_completed_response()
+                .map(|resp| resp.model.as_str()),
+            Some("openai-gpt-5.4"),
+            "completed response should retain the served model for tracing"
+        );
+    }
+
+    /// Anthropic upstreams nest the model under `message` on `message_start`.
+    #[test]
+    fn test_streaming_echoes_anthropic_upstream_model() {
+        let mut buffer = ResponsesAPIStreamBuffer::new();
+        buffer.add_transformed_event(SseEvent {
+            data: Some(
+                r#"{"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5","role":"assistant"}}"#
+                    .to_string(),
+            ),
+            event: Some("message_start".to_string()),
+            raw_line: String::new(),
+            sse_transformed_lines: String::new(),
+            provider_stream_response: None,
+        });
+        buffer.finalize();
+
+        let output = String::from_utf8_lossy(&buffer.to_bytes()).to_string();
+        assert!(
+            output.contains(r#""model":"claude-sonnet-4-5""#),
+            "should echo the nested Anthropic model, got:\n{}",
+            output
         );
     }
 }

--- a/crates/hermesllm/src/transforms/request/from_anthropic.rs
+++ b/crates/hermesllm/src/transforms/request/from_anthropic.rs
@@ -315,7 +315,7 @@ fn convert_anthropic_tool_choice(
 }
 
 /// Build OpenAI message content from parts and tool calls
-fn build_openai_content(
+pub(crate) fn build_openai_content(
     content_parts: Vec<ContentPart>,
     tool_calls: &[ToolCall],
 ) -> Option<MessageContent> {

--- a/crates/hermesllm/src/transforms/request/from_bedrock.rs
+++ b/crates/hermesllm/src/transforms/request/from_bedrock.rs
@@ -1,8 +1,21 @@
 use crate::apis::amazon_bedrock::{
-    ContentBlock, ConversationRole, Message as BedrockMessage, ToolResultContentBlock,
+    ContentBlock, ConversationRole, ImageSource, Message as BedrockMessage, ToolResultContentBlock,
 };
-use crate::apis::openai::{FunctionCall, Message, MessageContent, Role, ToolCall};
+use crate::apis::openai::{
+    ContentPart, FunctionCall, ImageUrl, Message, MessageContent, Role, ToolCall,
+};
 use crate::clients::TransformError;
+use crate::transforms::request::from_anthropic::build_openai_content;
+
+/// Render a Bedrock image source as the data URL an OpenAI image part carries. The
+/// inverse of `parse_data_url` on the to-Bedrock side, so images round-trip.
+fn image_source_to_url(source: &ImageSource) -> String {
+    match source {
+        ImageSource::Base64 { media_type, data } => {
+            format!("data:{};base64,{}", media_type, data)
+        }
+    }
+}
 
 /// Flatten Bedrock tool result content blocks into the single text payload that an
 /// OpenAI `tool` message carries.
@@ -28,13 +41,22 @@ impl TryFrom<BedrockMessage> for Vec<Message> {
             ConversationRole::Assistant => Role::Assistant,
         };
 
-        let mut text_parts = Vec::new();
+        let mut content_parts = Vec::new();
         let mut tool_calls = Vec::new();
         let mut tool_results = Vec::new();
 
         for block in message.content {
             match block {
-                ContentBlock::Text { text } => text_parts.push(text),
+                ContentBlock::Text { text } => content_parts.push(ContentPart::Text {
+                    text,
+                    cache_control: None,
+                }),
+                ContentBlock::Image { image } => content_parts.push(ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: image_source_to_url(&image.source),
+                        detail: None,
+                    },
+                }),
                 ContentBlock::ToolUse { tool_use } => {
                     tool_calls.push(ToolCall {
                         id: tool_use.tool_use_id,
@@ -51,9 +73,9 @@ impl TryFrom<BedrockMessage> for Vec<Message> {
                         flatten_tool_result_content(&tool_result.content),
                     ));
                 }
-                ContentBlock::Image { .. }
-                | ContentBlock::Document { .. }
-                | ContentBlock::GuardContent { .. } => continue,
+                // Documents have no OpenAI content-part equivalent, and guard content is
+                // Bedrock-side policy metadata rather than conversation content.
+                ContentBlock::Document { .. } | ContentBlock::GuardContent { .. } => continue,
             }
         }
 
@@ -70,11 +92,12 @@ impl TryFrom<BedrockMessage> for Vec<Message> {
             })
             .collect();
 
-        let text = text_parts.join("\n");
-        if !text.is_empty() || !tool_calls.is_empty() || result.is_empty() {
+        // Normalized through the same helper Anthropic uses, so a single text block
+        // collapses to plain text and an image survives as a content part on both.
+        if !content_parts.is_empty() || !tool_calls.is_empty() || result.is_empty() {
             result.push(Message {
                 role,
-                content: Some(MessageContent::Text(text)),
+                content: build_openai_content(content_parts, &tool_calls),
                 name: None,
                 tool_calls: if tool_calls.is_empty() {
                     None
@@ -183,6 +206,77 @@ mod tests {
         assert_eq!(tool_calls[0].id, "call_1");
         assert_eq!(tool_calls[0].function.name, "get_weather");
         assert_eq!(tool_calls[0].function.arguments, r#"{"city":"Seattle"}"#);
+    }
+
+    /// An uncaptioned screenshot must survive as an image part, not collapse to empty
+    /// text — otherwise it reads as an empty user message and Bedrock behaves
+    /// differently from OpenAI and Anthropic at the routing gate.
+    #[test]
+    fn test_bedrock_image_only_message_keeps_image_part() {
+        use crate::apis::amazon_bedrock::ImageBlock;
+
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::User,
+            content: vec![ContentBlock::Image {
+                image: ImageBlock {
+                    source: ImageSource::Base64 {
+                        media_type: "image/png".to_string(),
+                        data: "iVBORw0KGgo=".to_string(),
+                    },
+                },
+            }],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::User);
+        match messages[0].content.as_ref().expect("content") {
+            MessageContent::Parts(parts) => match &parts[0] {
+                ContentPart::ImageUrl { image_url } => {
+                    assert_eq!(image_url.url, "data:image/png;base64,iVBORw0KGgo=");
+                }
+                other => panic!("expected an image part, got {other:?}"),
+            },
+            other => panic!("expected parts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_image_survives_a_round_trip_to_bedrock() {
+        use crate::apis::amazon_bedrock::ImageBlock;
+
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "what is this?".to_string(),
+                },
+                ContentBlock::Image {
+                    image: ImageBlock {
+                        source: ImageSource::Base64 {
+                            media_type: "image/png".to_string(),
+                            data: "iVBORw0KGgo=".to_string(),
+                        },
+                    },
+                },
+            ],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+        let back = BedrockMessage::try_from(messages[0].clone()).unwrap();
+
+        assert_eq!(back.content.len(), 2);
+        assert!(matches!(back.content[0], ContentBlock::Text { .. }));
+        match &back.content[1] {
+            ContentBlock::Image { image } => match &image.source {
+                ImageSource::Base64 { media_type, data } => {
+                    assert_eq!(media_type, "image/png");
+                    assert_eq!(data, "iVBORw0KGgo=");
+                }
+            },
+            other => panic!("expected an image block, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hermesllm/src/transforms/request/from_bedrock.rs
+++ b/crates/hermesllm/src/transforms/request/from_bedrock.rs
@@ -1,0 +1,203 @@
+use crate::apis::amazon_bedrock::{
+    ContentBlock, ConversationRole, Message as BedrockMessage, ToolResultContentBlock,
+};
+use crate::apis::openai::{FunctionCall, Message, MessageContent, Role, ToolCall};
+use crate::clients::TransformError;
+
+/// Flatten Bedrock tool result content blocks into the single text payload that an
+/// OpenAI `tool` message carries.
+pub(crate) fn flatten_tool_result_content(content: &[ToolResultContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            ToolResultContentBlock::Text { text } => Some(text.clone()),
+            ToolResultContentBlock::Json { json } => serde_json::to_string(json).ok(),
+            ToolResultContentBlock::Image { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// Message Conversions
+impl TryFrom<BedrockMessage> for Vec<Message> {
+    type Error = TransformError;
+
+    fn try_from(message: BedrockMessage) -> Result<Self, Self::Error> {
+        let role = match message.role {
+            ConversationRole::User => Role::User,
+            ConversationRole::Assistant => Role::Assistant,
+        };
+
+        let mut text_parts = Vec::new();
+        let mut tool_calls = Vec::new();
+        let mut tool_results = Vec::new();
+
+        for block in message.content {
+            match block {
+                ContentBlock::Text { text } => text_parts.push(text),
+                ContentBlock::ToolUse { tool_use } => {
+                    tool_calls.push(ToolCall {
+                        id: tool_use.tool_use_id,
+                        call_type: "function".to_string(),
+                        function: FunctionCall {
+                            name: tool_use.name,
+                            arguments: serde_json::to_string(&tool_use.input)?,
+                        },
+                    });
+                }
+                ContentBlock::ToolResult { tool_result } => {
+                    tool_results.push((
+                        tool_result.tool_use_id,
+                        flatten_tool_result_content(&tool_result.content),
+                    ));
+                }
+                ContentBlock::Image { .. }
+                | ContentBlock::Document { .. }
+                | ContentBlock::GuardContent { .. } => continue,
+            }
+        }
+
+        // Tool results come first, mirroring the Anthropic split: a Bedrock user message
+        // that only carries tool results must not surface as a trailing user message.
+        let mut result: Vec<Message> = tool_results
+            .into_iter()
+            .map(|(tool_use_id, text)| Message {
+                role: Role::Tool,
+                content: Some(MessageContent::Text(text)),
+                name: None,
+                tool_calls: None,
+                tool_call_id: Some(tool_use_id),
+            })
+            .collect();
+
+        let text = text_parts.join("\n");
+        if !text.is_empty() || !tool_calls.is_empty() || result.is_empty() {
+            result.push(Message {
+                role,
+                content: Some(MessageContent::Text(text)),
+                name: None,
+                tool_calls: if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls)
+                },
+                tool_call_id: None,
+            });
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::apis::amazon_bedrock::{ToolResultBlock, ToolResultStatus, ToolUseBlock};
+    use serde_json::json;
+
+    #[test]
+    fn test_bedrock_tool_result_becomes_tool_message() {
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_result: ToolResultBlock {
+                    tool_use_id: "call_1".to_string(),
+                    content: vec![ToolResultContentBlock::Text {
+                        text: "72F and sunny".to_string(),
+                    }],
+                    status: Some(ToolResultStatus::Success),
+                },
+            }],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::Tool);
+        assert_eq!(messages[0].tool_call_id, Some("call_1".to_string()));
+        assert_eq!(
+            messages[0].content.as_ref().map(|c| c.to_string()),
+            Some("72F and sunny".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bedrock_tool_result_with_trailing_text_keeps_user_message_last() {
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::User,
+            content: vec![
+                ContentBlock::ToolResult {
+                    tool_result: ToolResultBlock {
+                        tool_use_id: "call_1".to_string(),
+                        content: vec![ToolResultContentBlock::Json {
+                            json: json!({"temp": 72}),
+                        }],
+                        status: None,
+                    },
+                },
+                ContentBlock::Text {
+                    text: "now write the tests".to_string(),
+                },
+            ],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, Role::Tool);
+        assert_eq!(
+            messages[0].content.as_ref().map(|c| c.to_string()),
+            Some(r#"{"temp":72}"#.to_string())
+        );
+        assert_eq!(messages[1].role, Role::User);
+        assert_eq!(
+            messages[1].content.as_ref().map(|c| c.to_string()),
+            Some("now write the tests".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bedrock_tool_use_becomes_assistant_tool_calls() {
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::Assistant,
+            content: vec![
+                ContentBlock::Text {
+                    text: "Checking the weather".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    tool_use: ToolUseBlock {
+                        tool_use_id: "call_1".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"city": "Seattle"}),
+                    },
+                },
+            ],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::Assistant);
+        let tool_calls = messages[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, r#"{"city":"Seattle"}"#);
+    }
+
+    #[test]
+    fn test_bedrock_text_only_message_round_trips() {
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::User,
+            content: vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+        };
+
+        let messages: Vec<Message> = bedrock_message.try_into().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::User);
+        assert!(messages[0].tool_calls.is_none());
+    }
+}

--- a/crates/hermesllm/src/transforms/request/from_openai.rs
+++ b/crates/hermesllm/src/transforms/request/from_openai.rs
@@ -13,6 +13,7 @@ use crate::apis::openai::{
     ChatCompletionsRequest, FunctionCall as OpenAIFunctionCall, Message, MessageContent, Role,
     Tool, ToolCall as OpenAIToolCall, ToolChoice, ToolChoiceType,
 };
+use log::warn;
 
 use crate::apis::openai_responses::{
     InputContent, InputItem, InputParam, MessageRole, Modality, NamespaceTool, ReasoningEffort,
@@ -259,11 +260,26 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                                 },
                             );
                         }
-                        InputItem::ItemReference { .. }
-                        | InputItem::Reasoning { .. }
-                        | InputItem::Ignored(_) => {
-                            // Item references, reasoning, and other typed items are not
-                            // representable in Chat Completions and are skipped.
+                        InputItem::ItemReference { .. } | InputItem::Reasoning { .. } => {
+                            // Item references and reasoning are not representable in Chat
+                            // Completions and are skipped.
+                        }
+                        InputItem::Ignored(value) => {
+                            // Unknown typed items are preserved on a Responses passthrough
+                            // but have no Chat Completions form, so they are dropped here.
+                            // A *known* tool-call type that landed in `Ignored` is malformed
+                            // (e.g. a `function_call` missing `arguments`); dropping it
+                            // silently leaves its `function_call_output` orphaned upstream,
+                            // so make that visible rather than corrupting the context quietly.
+                            let item_type = value.get("type").and_then(|t| t.as_str());
+                            if matches!(item_type, Some("function_call") | Some("custom_tool_call"))
+                            {
+                                warn!(
+                                    "dropping malformed {} input item; its tool result will \
+                                     have no matching call upstream",
+                                    item_type.unwrap_or("tool call")
+                                );
+                            }
                         }
                     }
                 }
@@ -1727,6 +1743,40 @@ mod tests {
                 .as_ref()
                 .map(|c| c.to_string()),
             Some("test result: ok".to_string())
+        );
+    }
+
+    /// A `function_call` missing `arguments` is malformed, so it degrades to a preserved
+    /// raw item rather than failing the parse. Chat Completions has no form for it, so it
+    /// is dropped — documenting that the paired output is left orphaned upstream. The
+    /// drop is logged (see the `InputItem::Ignored` arm) instead of being silent.
+    #[test]
+    fn test_responses_malformed_function_call_is_dropped_leaving_output_orphaned() {
+        use crate::apis::openai_responses::ResponsesAPIRequest;
+
+        let json = serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": [
+                {"role": "user", "content": "pwd"},
+                // No `arguments` — does not match the typed shape.
+                {"type": "function_call", "call_id": "call_1", "name": "exec_command"},
+                {"type": "function_call_output", "call_id": "call_1", "output": "/tmp"}
+            ]
+        });
+        let req: ResponsesAPIRequest = serde_json::from_value(json).expect("should parse");
+        let converted = ChatCompletionsRequest::try_from(req).expect("conversion should succeed");
+
+        // The user message and the tool output survive; the malformed call does not.
+        assert_eq!(converted.messages.len(), 2);
+        assert!(matches!(converted.messages[0].role, Role::User));
+        assert!(matches!(converted.messages[1].role, Role::Tool));
+        assert_eq!(
+            converted.messages[1].tool_call_id.as_deref(),
+            Some("call_1")
+        );
+        assert!(
+            converted.messages.iter().all(|m| m.tool_calls.is_none()),
+            "the malformed call must not be synthesized into a tool call"
         );
     }
 }

--- a/crates/hermesllm/src/transforms/request/from_openai.rs
+++ b/crates/hermesllm/src/transforms/request/from_openai.rs
@@ -15,7 +15,7 @@ use crate::apis::openai::{
 };
 
 use crate::apis::openai_responses::{
-    InputContent, InputItem, InputParam, MessageRole, Modality, ReasoningEffort,
+    InputContent, InputItem, InputParam, MessageRole, Modality, NamespaceTool, ReasoningEffort,
     ResponsesAPIRequest, Tool as ResponsesTool, ToolChoice as ResponsesToolChoice,
 };
 use crate::clients::TransformError;
@@ -509,6 +509,36 @@ impl TryFrom<ResponsesAPIRequest> for ChatCompletionsRequest {
             base
         }
 
+        // Custom tools have no strict ChatCompletions equivalent across providers, so
+        // they degrade to a permissive function tool. Shared by top-level custom tools
+        // and namespace members.
+        fn custom_tool_as_function(
+            name: Option<String>,
+            description: Option<String>,
+            format: Option<serde_json::Value>,
+            fallback_name: String,
+        ) -> Tool {
+            Tool {
+                tool_type: "function".to_string(),
+                function: crate::apis::openai::Function {
+                    name: name.unwrap_or(fallback_name),
+                    description,
+                    parameters: normalize_function_parameters(
+                        Some(serde_json::json!({
+                            "type": "object",
+                            "properties": {
+                                "input": { "type": "string" }
+                            },
+                            "required": ["input"],
+                            "additionalProperties": true,
+                        })),
+                        format,
+                    ),
+                    strict: Some(false),
+                },
+            }
+        }
+
         let mut converted_chat_tools: Vec<Tool> = Vec::new();
         let mut web_search_options: Option<serde_json::Value> = None;
 
@@ -586,30 +616,48 @@ impl TryFrom<ResponsesAPIRequest> for ChatCompletionsRequest {
                         description,
                         format,
                     } => {
-                        // Custom tools do not have a strict ChatCompletions equivalent for all
-                        // providers. Map them to a permissive function tool for compatibility.
-                        let tool_name = name.unwrap_or_else(|| format!("custom_tool_{}", idx + 1));
-                        let parameters = normalize_function_parameters(
-                            Some(serde_json::json!({
-                                "type": "object",
-                                "properties": {
-                                    "input": { "type": "string" }
-                                },
-                                "required": ["input"],
-                                "additionalProperties": true,
-                            })),
+                        converted_chat_tools.push(custom_tool_as_function(
+                            name,
+                            description,
                             format,
-                        );
-
-                        converted_chat_tools.push(Tool {
-                            tool_type: "function".to_string(),
-                            function: crate::apis::openai::Function {
-                                name: tool_name,
-                                description,
-                                parameters,
-                                strict: Some(false),
-                            },
-                        });
+                            format!("custom_tool_{}", idx + 1),
+                        ));
+                    }
+                    ResponsesTool::Namespace { tools: members, .. } => {
+                        // ChatCompletions has no grouping construct, so members are hoisted
+                        // to top-level function tools. Member names are kept verbatim: the
+                        // model answers with the same name the client registered, which is
+                        // what lets the tool call be matched when it is translated back.
+                        for (member_idx, member) in members.into_iter().enumerate() {
+                            let tool = match member {
+                                NamespaceTool::Function {
+                                    name,
+                                    description,
+                                    parameters,
+                                    strict,
+                                    ..
+                                } => Tool {
+                                    tool_type: "function".to_string(),
+                                    function: crate::apis::openai::Function {
+                                        name,
+                                        description,
+                                        parameters: normalize_function_parameters(parameters, None),
+                                        strict,
+                                    },
+                                },
+                                NamespaceTool::Custom {
+                                    name,
+                                    description,
+                                    format,
+                                } => custom_tool_as_function(
+                                    name,
+                                    description,
+                                    format,
+                                    format!("custom_tool_{}_{}", idx + 1, member_idx + 1),
+                                ),
+                            };
+                            converted_chat_tools.push(tool);
+                        }
                     }
                     ResponsesTool::FileSearch { .. } => {
                         return Err(TransformError::UnsupportedConversion(
@@ -1292,6 +1340,76 @@ mod tests {
             tools[0].function.description.as_deref(),
             Some("Apply structured patch")
         );
+    }
+
+    /// ChatCompletions has no namespace construct, so grouped tools have to arrive
+    /// upstream as ordinary function tools or the model cannot call them at all.
+    #[test]
+    fn test_responses_namespace_tool_flattens_to_function_tools_for_chat_completions() {
+        use crate::apis::openai_responses::{
+            InputParam, NamespaceTool, ResponsesAPIRequest, Tool as ResponsesTool,
+        };
+
+        let req = ResponsesAPIRequest {
+            model: "gpt-5.3-codex".to_string(),
+            input: InputParam::Text("look up a customer".to_string()),
+            tools: Some(vec![ResponsesTool::Namespace {
+                name: "crm".to_string(),
+                description: "CRM tools".to_string(),
+                tools: vec![
+                    NamespaceTool::Function {
+                        name: "get_customer_profile".to_string(),
+                        description: Some("Fetch a customer profile".to_string()),
+                        parameters: Some(serde_json::json!({
+                            "type": "object",
+                            "properties": { "customer_id": { "type": "string" } },
+                            "required": ["customer_id"]
+                        })),
+                        strict: Some(true),
+                        defer_loading: None,
+                        output_schema: None,
+                    },
+                    NamespaceTool::Custom {
+                        name: Some("run_patch".to_string()),
+                        description: Some("Apply structured patch".to_string()),
+                        format: None,
+                    },
+                ],
+            }]),
+            include: None,
+            parallel_tool_calls: None,
+            store: None,
+            instructions: None,
+            stream: None,
+            stream_options: None,
+            conversation: None,
+            tool_choice: None,
+            max_output_tokens: None,
+            temperature: None,
+            top_p: None,
+            metadata: None,
+            previous_response_id: None,
+            modalities: None,
+            audio: None,
+            text: None,
+            reasoning_effort: None,
+            truncation: None,
+            user: None,
+            max_tool_calls: None,
+            service_tier: None,
+            background: None,
+            top_logprobs: None,
+        };
+
+        let converted = ChatCompletionsRequest::try_from(req).expect("conversion should succeed");
+        let tools = converted.tools.expect("tools should be present");
+        assert_eq!(tools.len(), 2);
+        // Names are kept verbatim so a tool call translated back is still recognizable
+        // to the client that registered it.
+        assert_eq!(tools[0].function.name, "get_customer_profile");
+        assert_eq!(tools[0].tool_type, "function");
+        assert_eq!(tools[1].function.name, "run_patch");
+        assert_eq!(tools[1].tool_type, "function");
     }
 
     #[test]

--- a/crates/hermesllm/src/transforms/request/from_openai.rs
+++ b/crates/hermesllm/src/transforms/request/from_openai.rs
@@ -34,6 +34,28 @@ pub struct ResponsesInputConverter {
     pub instructions: Option<String>,
 }
 
+/// Record a tool call in the message list, attaching it to the preceding assistant
+/// message when there is one so parallel calls stay on a single message.
+fn push_tool_call(messages: &mut Vec<Message>, tool_call: OpenAIToolCall) {
+    if let Some(last) = messages.last_mut() {
+        if matches!(last.role, Role::Assistant) {
+            match &mut last.tool_calls {
+                Some(existing) => existing.push(tool_call),
+                None => last.tool_calls = Some(vec![tool_call]),
+            }
+            return;
+        }
+    }
+
+    messages.push(Message {
+        role: Role::Assistant,
+        content: None,
+        name: None,
+        tool_call_id: None,
+        tool_calls: Some(vec![tool_call]),
+    });
+}
+
 impl TryFrom<ResponsesInputConverter> for Vec<Message> {
     type Error = TransformError;
 
@@ -185,6 +207,9 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                         }
                         InputItem::FunctionCallOutput {
                             call_id, output, ..
+                        }
+                        | InputItem::CustomToolCallOutput {
+                            call_id, output, ..
                         } => {
                             // Preserve tool result so upstream models do not re-issue the same tool call.
                             let output_text = match output {
@@ -205,31 +230,34 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                             call_id,
                             ..
                         } => {
-                            let tool_call = OpenAIToolCall {
-                                id: call_id,
-                                call_type: "function".to_string(),
-                                function: OpenAIFunctionCall { name, arguments },
-                            };
-
-                            // Prefer attaching tool_calls to the preceding assistant message when present.
-                            if let Some(last) = converted_messages.last_mut() {
-                                if matches!(last.role, Role::Assistant) {
-                                    if let Some(existing) = &mut last.tool_calls {
-                                        existing.push(tool_call);
-                                    } else {
-                                        last.tool_calls = Some(vec![tool_call]);
-                                    }
-                                    continue;
-                                }
-                            }
-
-                            converted_messages.push(Message {
-                                role: Role::Assistant,
-                                content: None,
-                                name: None,
-                                tool_call_id: None,
-                                tool_calls: Some(vec![tool_call]),
-                            });
+                            push_tool_call(
+                                &mut converted_messages,
+                                OpenAIToolCall {
+                                    id: call_id,
+                                    call_type: "function".to_string(),
+                                    function: OpenAIFunctionCall { name, arguments },
+                                },
+                            );
+                        }
+                        InputItem::CustomToolCall {
+                            name,
+                            input,
+                            call_id,
+                            ..
+                        } => {
+                            // Custom tool input is free-form text. Wrap it in the same
+                            // `{"input": ...}` envelope that `custom_tool_as_function`
+                            // advertises for the tool itself, so the replayed call matches
+                            // the schema the upstream was given.
+                            let arguments = serde_json::json!({ "input": input }).to_string();
+                            push_tool_call(
+                                &mut converted_messages,
+                                OpenAIToolCall {
+                                    id: call_id,
+                                    call_type: "function".to_string(),
+                                    function: OpenAIFunctionCall { name, arguments },
+                                },
+                            );
                         }
                         InputItem::ItemReference { .. }
                         | InputItem::Reasoning { .. }
@@ -1640,6 +1668,65 @@ mod tests {
         assert_eq!(
             converted.messages[2].tool_call_id.as_deref(),
             Some("call_1")
+        );
+    }
+
+    /// A Codex custom-tool step: the call becomes an assistant tool call carrying the
+    /// free-form input in the `{"input": ...}` envelope the tool was advertised with,
+    /// and the output becomes a tool message linked by `call_id`.
+    #[test]
+    fn test_responses_custom_tool_call_and_output_map_to_tool_messages() {
+        use crate::apis::openai_responses::ResponsesAPIRequest;
+
+        let json = serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": [
+                {"role": "user", "content": "run the tests"},
+                {
+                    "type": "custom_tool_call",
+                    "id": "ctc_1",
+                    "call_id": "call_1",
+                    "name": "shell",
+                    "input": "cargo test",
+                    "status": "completed"
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_1",
+                    "output": "test result: ok"
+                }
+            ]
+        });
+        let req: ResponsesAPIRequest = serde_json::from_value(json).expect("should parse");
+        let converted = ChatCompletionsRequest::try_from(req).expect("conversion should succeed");
+
+        assert_eq!(converted.messages.len(), 3);
+        assert!(matches!(converted.messages[0].role, Role::User));
+
+        assert!(matches!(converted.messages[1].role, Role::Assistant));
+        let tool_calls = converted.messages[1]
+            .tool_calls
+            .as_ref()
+            .expect("assistant tool_calls should be present");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(
+            tool_calls[0].function.arguments,
+            r#"{"input":"cargo test"}"#
+        );
+
+        assert!(matches!(converted.messages[2].role, Role::Tool));
+        assert_eq!(
+            converted.messages[2].tool_call_id.as_deref(),
+            Some("call_1")
+        );
+        assert_eq!(
+            converted.messages[2]
+                .content
+                .as_ref()
+                .map(|c| c.to_string()),
+            Some("test result: ok".to_string())
         );
     }
 }

--- a/crates/hermesllm/src/transforms/request/from_openai.rs
+++ b/crates/hermesllm/src/transforms/request/from_openai.rs
@@ -184,9 +184,7 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                             });
                         }
                         InputItem::FunctionCallOutput {
-                            item_type: _,
-                            call_id,
-                            output,
+                            call_id, output, ..
                         } => {
                             // Preserve tool result so upstream models do not re-issue the same tool call.
                             let output_text = match output {
@@ -202,10 +200,10 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                             });
                         }
                         InputItem::FunctionCall {
-                            item_type: _,
                             name,
                             arguments,
                             call_id,
+                            ..
                         } => {
                             let tool_call = OpenAIToolCall {
                                 id: call_id,
@@ -233,9 +231,11 @@ impl TryFrom<ResponsesInputConverter> for Vec<Message> {
                                 tool_calls: Some(vec![tool_call]),
                             });
                         }
-                        InputItem::ItemReference { .. } => {
-                            // Item references/unknown entries are metadata-like and can be skipped
-                            // for chat-completions conversion.
+                        InputItem::ItemReference { .. }
+                        | InputItem::Reasoning { .. }
+                        | InputItem::Ignored(_) => {
+                            // Item references, reasoning, and other typed items are not
+                            // representable in Chat Completions and are skipped.
                         }
                     }
                 }
@@ -1470,9 +1470,10 @@ mod tests {
         let req = ResponsesAPIRequest {
             model: "gpt-5.3-codex".to_string(),
             input: InputParam::Items(vec![InputItem::FunctionCallOutput {
-                item_type: "function_call_output".to_string(),
                 call_id: "call_123".to_string(),
                 output: serde_json::json!({"status":"ok","stdout":"hello"}),
+                id: None,
+                status: None,
             }]),
             tools: Some(vec![ResponsesTool::Function {
                 name: "exec_command".to_string(),
@@ -1535,15 +1536,17 @@ mod tests {
                     content: ResponsesMessageContent::Items(vec![]),
                 }),
                 InputItem::FunctionCall {
-                    item_type: "function_call".to_string(),
                     name: "exec_command".to_string(),
                     arguments: "{\"cmd\":\"pwd\"}".to_string(),
                     call_id: "toolu_abc123".to_string(),
+                    id: None,
+                    status: None,
                 },
                 InputItem::FunctionCallOutput {
-                    item_type: "function_call_output".to_string(),
                     call_id: "toolu_abc123".to_string(),
                     output: serde_json::Value::String("ok".to_string()),
+                    id: None,
+                    status: None,
                 },
             ]),
             tools: None,
@@ -1587,6 +1590,56 @@ mod tests {
         assert_eq!(
             converted.messages[1].tool_call_id.as_deref(),
             Some("toolu_abc123")
+        );
+    }
+
+    /// Codex-shaped payload: function_call / function_call_output carry `id`,
+    /// and a reasoning item sits in the list. Conversion must keep the tool
+    /// call ↔ output link and skip reasoning.
+    #[test]
+    fn test_responses_function_call_with_id_converts_and_skips_reasoning() {
+        use crate::apis::openai_responses::ResponsesAPIRequest;
+
+        let json = serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": [
+                {"role": "user", "content": "pwd"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": []
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                    "status": "completed"
+                },
+                {
+                    "type": "function_call_output",
+                    "id": "fc_out_1",
+                    "call_id": "call_1",
+                    "output": "/tmp"
+                }
+            ]
+        });
+        let req: ResponsesAPIRequest = serde_json::from_value(json).expect("should parse");
+        let converted = ChatCompletionsRequest::try_from(req).expect("conversion should succeed");
+
+        assert_eq!(converted.messages.len(), 3);
+        assert!(matches!(converted.messages[0].role, Role::User));
+        assert!(matches!(converted.messages[1].role, Role::Assistant));
+        let tool_calls = converted.messages[1]
+            .tool_calls
+            .as_ref()
+            .expect("assistant tool_calls should be present");
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert!(matches!(converted.messages[2].role, Role::Tool));
+        assert_eq!(
+            converted.messages[2].tool_call_id.as_deref(),
+            Some("call_1")
         );
     }
 }

--- a/crates/hermesllm/src/transforms/request/mod.rs
+++ b/crates/hermesllm/src/transforms/request/mod.rs
@@ -1,4 +1,5 @@
 //! Request transformation modules
 
 pub mod from_anthropic;
+pub mod from_bedrock;
 pub mod from_openai;

--- a/crates/hermesllm/src/transforms/response/to_openai.rs
+++ b/crates/hermesllm/src/transforms/response/to_openai.rs
@@ -357,6 +357,7 @@ fn convert_bedrock_message_to_openai(
 ) -> Result<(Option<String>, Option<Vec<crate::apis::openai::ToolCall>>), TransformError> {
     use crate::apis::amazon_bedrock::ContentBlock;
     use crate::apis::openai::{FunctionCall, ToolCall};
+    use crate::transforms::request::from_bedrock::flatten_tool_result_content;
 
     let mut text_content = String::new();
     let mut tool_calls = Vec::new();
@@ -375,6 +376,12 @@ fn convert_bedrock_message_to_openai(
                         arguments: serde_json::to_string(&tool_use.input).unwrap_or_default(),
                     },
                 });
+            }
+            ContentBlock::ToolResult { tool_result } => {
+                // A model turn normally carries toolUse, not toolResult, but some Bedrock
+                // models echo results back. Fold the payload into the text so it is not lost;
+                // the response shape has no place for a separate tool message.
+                text_content.push_str(&flatten_tool_result_content(&tool_result.content));
             }
             _ => continue,
         }
@@ -783,6 +790,29 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["param"], "value");
+    }
+
+    #[test]
+    fn test_convert_bedrock_message_to_openai_keeps_tool_result_text() {
+        use crate::apis::amazon_bedrock::{ToolResultBlock, ToolResultContentBlock};
+
+        let bedrock_message = BedrockMessage {
+            role: ConversationRole::Assistant,
+            content: vec![ContentBlock::ToolResult {
+                tool_result: ToolResultBlock {
+                    tool_use_id: "test_tool".to_string(),
+                    content: vec![ToolResultContentBlock::Text {
+                        text: "72F".to_string(),
+                    }],
+                    status: None,
+                },
+            }],
+        };
+
+        let (content, tool_calls) = convert_bedrock_message_to_openai(&bedrock_message).unwrap();
+
+        assert_eq!(content, Some("72F".to_string()));
+        assert!(tool_calls.is_none());
     }
 
     #[test]

--- a/demos/llm_routing/claude_code_router/README.md
+++ b/demos/llm_routing/claude_code_router/README.md
@@ -29,6 +29,10 @@ Your Request → Plano → Suitable Model → Response
     [Task Analysis & Model Selection]
 ```
 
+Claude Code answers one request with a whole loop of LLM calls — it writes code, runs tools, reads the results and continues. Model selection happens once, on your message; the tool steps that follow stay on the model that started the turn, so a single answer is never split across models. Your next message is routed fresh.
+
+Claude Code's small/fast model (`ANTHROPIC_SMALL_FAST_MODEL`) is a separate lane and keeps routing on its own.
+
 **Supported Providers**: OpenAI-compatible, Anthropic, DeepSeek, Grok, Gemini, Llama, Mistral, local models via Ollama. See [full list of supported providers](https://docs.planoai.dev/concepts/llm_providers/supported_providers.html).
 
 

--- a/demos/llm_routing/claude_code_router/config.yaml
+++ b/demos/llm_routing/claude_code_router/config.yaml
@@ -37,5 +37,8 @@ model_aliases:
   arch.claude.code.small.fast:
     target: claude-haiku-4-5
 
+routing:
+  route_on_user_turn: true
+
 tracing:
   random_sampling: 100

--- a/demos/llm_routing/claude_code_router/config.yaml
+++ b/demos/llm_routing/claude_code_router/config.yaml
@@ -38,7 +38,7 @@ model_aliases:
     target: claude-haiku-4-5
 
 routing:
-  auto_pin_tool_calls: true
+  route_on_user_only: true
 
 tracing:
   random_sampling: 100

--- a/demos/llm_routing/claude_code_router/config.yaml
+++ b/demos/llm_routing/claude_code_router/config.yaml
@@ -38,7 +38,7 @@ model_aliases:
     target: claude-haiku-4-5
 
 routing:
-  route_on_user_turn: true
+  auto_pin_tool_calls: true
 
 tracing:
   random_sampling: 100

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -126,11 +126,11 @@ routing_preferences:
 
 ## When routing runs
 
-By default the quality router runs on every request. Set `routing.route_on_user_turn` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
+By default the quality router runs on every request. Set `routing.auto_pin_tool_calls` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
 
 ```yaml
 routing:
-  route_on_user_turn: true
+  auto_pin_tool_calls: true
 ```
 
 Omit the key (or set it `false`) to keep per-request routing. When enabled, it works with no client changes for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items all normalize to a non-user tail:

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -163,7 +163,7 @@ Across client APIs that means:
 
 - OpenAI Chat: the last message is `role: "user"`
 - Anthropic: the last content is user text (a `tool_result`-only turn normalizes to `role: "tool"`)
-- Responses: the last item is not a `function_call_output`
+- Responses: the last item is not a `function_call_output` or `custom_tool_call_output` (Codex registers custom tools by default, so its steps use the latter)
 - Bedrock Converse: the last message carries user text, not only `toolResult` blocks
 
 A new user message always re-routes, including Anthropic packing new user text alongside a `tool_result`.
@@ -183,6 +183,8 @@ Skips are observable: the `plano.routing.skipped` span attribute and the `bright
 ## Model Affinity
 
 The user-turn check covers a single query. To keep a whole *conversation* on one model — across user turns — send an `X-Model-Affinity` header. Without it, Plano derives an implicit session key from the stable prompt prefix (system + tools + first user message), which is what makes replay work header-free.
+
+**Use one id per conversation, not one per client session.** A session key holds a single binding, so if side calls (a side chat, a summarizer, a subagent) share the main loop's id, whichever ran last owns the binding. The lane and prefix guards keep the side call from being pinned to the main loop's model, but the loop's own pin is evicted, and its next continuation re-routes. Give side calls their own id, or omit the header and let implicit affinity separate them by prompt prefix.
 
 ```json
 POST /v1/chat/completions

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -124,26 +124,31 @@ routing_preferences:
 
 ---
 
-## Agentic Loops
+## When routing runs
 
-A coding agent answers one user turn with many LLM calls: the model replies with tool calls, the client runs them and posts the results back for the next step. Re-routing each of those steps would let a single turn drift across models mid-generation, which breaks the client — tool-call ids, reasoning state and the provider's prompt cache all belong to the model that started the turn.
+By default the quality router runs on every request. Set `routing.route_on_user_turn` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
 
-Plano detects these steps and replays the decision the loop already made instead of routing again. It works out of the box, with no client changes, for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items:
+```yaml
+routing:
+  route_on_user_turn: true
+```
+
+Omit the key (or set it `false`) to keep per-request routing. When enabled, it works with no client changes for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items all normalize to a non-user tail:
 
 ```text
 user message      -> routing picks a model
 tool result       -> replays it (routing skipped)
-tool result       -> replays it (routing skipped)
+assistant step    -> replays it (routing skipped)
 next user message -> routing runs again, free to pick a different model
 ```
 
-Routing is skipped only while a loop is in flight. A new user message always re-routes, so intent-based selection keeps working turn to turn. A step also re-routes when the loop can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
+A step also re-routes when the prior decision can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
 
 Skips are observable: the `plano.routing.skipped` span attribute and the `brightstaff_router_skips_total` counter.
 
 ## Model Affinity
 
-Loop detection covers a single turn. To keep a whole *conversation* on one model — across user turns, or when your client's requests don't look like a tool loop — send an `X-Model-Affinity` header. Without it, Plano derives an implicit session key from the stable prompt prefix (system + tools + first user message), which is what makes loop replay work header-free.
+The user-turn check covers a single query. To keep a whole *conversation* on one model — across user turns — send an `X-Model-Affinity` header. Without it, Plano derives an implicit session key from the stable prompt prefix (system + tools + first user message), which is what makes replay work header-free.
 
 ```json
 POST /v1/chat/completions

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -126,11 +126,11 @@ routing_preferences:
 
 ## When routing runs
 
-By default the quality router runs on every request. Set `routing.auto_pin_tool_calls` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
+By default the quality router runs on every request. Set `routing.route_on_user_only` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
 
 ```yaml
 routing:
-  auto_pin_tool_calls: true
+  route_on_user_only: true
 ```
 
 Omit the key (or set it `false`) to keep per-request routing. When enabled, it works with no client changes for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items all normalize to a non-user tail:

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -157,19 +157,24 @@ Use turn-level routing for:
 
 ### When routing occurs
 
-A routing decision is made when the incoming request represents the **start of a new user turn**: the last normalized message has `role: "user"`. That is genuine user text, not a tool result being fed back into an in-flight loop.
+A routing decision is made when the incoming request represents the **start of a new user turn**: the last normalized message has `role: "user"` and still carries text once harness-injected envelopes are removed. That is genuine user text, not a tool result being fed back into an in-flight loop.
 
 Across client APIs that means:
 
 - OpenAI Chat: the last message is `role: "user"`
 - Anthropic: the last content is user text (a `tool_result`-only turn normalizes to `role: "tool"`)
 - Responses: the last item is not a `function_call_output`
+- Bedrock Converse: the last message carries user text, not only `toolResult` blocks
 
 A new user message always re-routes, including Anthropic packing new user text alongside a `tool_result`.
 
+An empty user message, or one containing only Claude Code's `<system-reminder>` / `<user-prompt-submit-hook>` envelopes, is harness output rather than an utterance, so the loop stays pinned. An attachment with no caption (a pasted image) is user input and does route.
+
+**Known limitation.** Agent frameworks that feed tool output back as plain user prose — ReAct's `Observation: ...`, for example — are indistinguishable from a real user message on the wire, so each step re-routes. Send tool output as `role: "tool"` (or Anthropic `tool_result` / Responses `function_call_output`) to get turn-level pinning.
+
 ### When routing is skipped (sticky)
 
-Routing is skipped and the previously selected model is reused when the request is a **continuation of an in-flight agentic loop** — the last normalized message is not a user turn (tool results, assistant steps, unresolved `tool_use`). The request is pinned to the model recorded for the current turn.
+Routing is skipped and the previously selected model is reused when the request is a **continuation of an in-flight agentic loop** — the last normalized message is not a user turn (tool results, assistant steps, unresolved `tool_use`, or an empty / envelope-only user message). The request is pinned to the model recorded for the current turn.
 
 A step still re-routes when that prior decision can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
 

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -124,9 +124,26 @@ routing_preferences:
 
 ---
 
+## Agentic Loops
+
+A coding agent answers one user turn with many LLM calls: the model replies with tool calls, the client runs them and posts the results back for the next step. Re-routing each of those steps would let a single turn drift across models mid-generation, which breaks the client — tool-call ids, reasoning state and the provider's prompt cache all belong to the model that started the turn.
+
+Plano detects these steps and replays the decision the loop already made instead of routing again. It works out of the box, with no client changes, for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items:
+
+```text
+user message      -> routing picks a model
+tool result       -> replays it (routing skipped)
+tool result       -> replays it (routing skipped)
+next user message -> routing runs again, free to pick a different model
+```
+
+Routing is skipped only while a loop is in flight. A new user message always re-routes, so intent-based selection keeps working turn to turn. A step also re-routes when the loop can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
+
+Skips are observable: the `plano.routing.skipped` span attribute and the `brightstaff_router_skips_total` counter.
+
 ## Model Affinity
 
-In agentic loops where the same session makes multiple LLM calls, send an `X-Model-Affinity` header to pin the routing decision. The first request routes normally and caches the result. All subsequent requests with the same affinity ID return the cached model without re-running routing.
+Loop detection covers a single turn. To keep a whole *conversation* on one model — across user turns, or when your client's requests don't look like a tool loop — send an `X-Model-Affinity` header. Without it, Plano derives an implicit session key from the stable prompt prefix (system + tools + first user message), which is what makes loop replay work header-free.
 
 ```json
 POST /v1/chat/completions
@@ -157,7 +174,9 @@ Response when pinned:
 }
 ```
 
-Without the header, routing runs fresh every time (no breaking change).
+`pinned` reports that the session was warm on its bound model, so callers can treat it as a signal to keep that provider's cache warm.
+
+The decision endpoint applies the same loop handling as the proxy, so a client polling it between tool calls gets a stable answer for the whole turn.
 
 Configure TTL and cache size:
 

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -124,25 +124,54 @@ routing_preferences:
 
 ---
 
-## When routing runs
+## Per-request routing (default)
 
-By default the quality router runs on every request. Set `routing.route_on_user_only` to run it only when the last normalized message is a user turn. Tool results, assistant continuations, and anything else then replay the prior decision instead of asking the router again. That keeps a single user query from drifting across models mid-generation (tool-call ids, reasoning state, and the provider prompt cache all belong to the model that started the turn), while a new user message always re-routes so sequential tasks can pick a different model.
+Applies when `route_on_user_only` is `false` (the default). Every request is routed independently, including loop continuations. A single user turn may therefore be served by multiple models. For example, a lightweight model handling routine tool-orchestration iterations while a stronger model is selected for a complex reasoning step or the final synthesis.
+
+### When to use
+
+Use per-request routing for:
+
+- **Best model per step.** Each step in a turn is served by the model best matched to its difficulty or specialty.
+- **Cost efficiency.** Simple steps go to smaller models; only hard steps use expensive ones.
+- **Escalation on failure.** A struggling model can be swapped out for the remainder of the turn.
+- **Capacity flexibility.** Each request can be placed wherever capacity exists, with no pinning constraint.
+
+## Turn-level routing
+
+Applies when `route_on_user_only` is `true`. The router selects a model once per user turn and pins the remainder of the agentic loop to it.
 
 ```yaml
 routing:
   route_on_user_only: true
 ```
 
-Omit the key (or set it `false`) to keep per-request routing. When enabled, it works with no client changes for every supported client API — Anthropic `tool_result` blocks, OpenAI Chat `role: "tool"` messages, and Responses `function_call_output` items all normalize to a non-user tail:
+### When to use
 
-```text
-user message      -> routing picks a model
-tool result       -> replays it (routing skipped)
-assistant step    -> replays it (routing skipped)
-next user message -> routing runs again, free to pick a different model
-```
+Use turn-level routing for:
 
-A step also re-routes when the prior decision can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
+- **Plan consistency.** One model carries its own reasoning and plan through the entire loop.
+- **Cache locality.** Loop iterations reuse the shared prompt prefix cache; no switch-induced misses.
+- **No state translation.** Avoids stripping or converting model-specific artifacts (e.g., signed thinking blocks).
+- **Simpler parameter handling.** Engine-native parameters are resolved once per turn, not re-mapped per request.
+
+### When routing occurs
+
+A routing decision is made when the incoming request represents the **start of a new user turn**: the last normalized message has `role: "user"`. That is genuine user text, not a tool result being fed back into an in-flight loop.
+
+Across client APIs that means:
+
+- OpenAI Chat: the last message is `role: "user"`
+- Anthropic: the last content is user text (a `tool_result`-only turn normalizes to `role: "tool"`)
+- Responses: the last item is not a `function_call_output`
+
+A new user message always re-routes, including Anthropic packing new user text alongside a `tool_result`.
+
+### When routing is skipped (sticky)
+
+Routing is skipped and the previously selected model is reused when the request is a **continuation of an in-flight agentic loop** — the last normalized message is not a user turn (tool results, assistant steps, unresolved `tool_use`). The request is pinned to the model recorded for the current turn.
+
+A step still re-routes when that prior decision can no longer be identified — the session went cold, the system prompt or tool set changed, or the request is on a different model (Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` calls route independently of the main loop).
 
 Skips are observable: the `plano.routing.skipped` span attribute and the `brightstaff_router_skips_total` counter.
 

--- a/docs/source/guides/llm_router.rst
+++ b/docs/source/guides/llm_router.rst
@@ -587,6 +587,15 @@ When disabled (default), every LLM request is routed independently. When enabled
 
 Default: ``false``.
 
+A turn starts when the last message is from the user and still has text after Claude Code's
+``<system-reminder>`` and ``<user-prompt-submit-hook>`` envelopes are stripped, or carries an
+attachment such as an image. Empty or envelope-only user messages keep the loop pinned.
+
+Tool output must be sent as a tool message (OpenAI ``role: "tool"``, Anthropic ``tool_result``,
+Responses ``function_call_output``, or Bedrock ``toolResult``). Frameworks that feed results back
+as plain user prose, such as ReAct's ``Observation: ...``, look like real user turns on the wire
+and re-route on every step.
+
 .. _model_affinity:
 
 Model Affinity

--- a/docs/source/guides/llm_router.rst
+++ b/docs/source/guides/llm_router.rst
@@ -608,7 +608,7 @@ Without the header, routing runs fresh on every request — no behavior change f
       session_ttl_seconds: 600    # How long affinity lasts (default: 10 min)
       session_max_entries: 10000  # Max cached sessions (upper limit: 10000)
       # Opt-in: route only on a user turn; replay the prior model otherwise.
-      # route_on_user_turn: true
+      # auto_pin_tool_calls: true
 
 To start a new routing decision (e.g., when the agent's task changes), generate a new affinity ID.
 

--- a/docs/source/guides/llm_router.rst
+++ b/docs/source/guides/llm_router.rst
@@ -573,6 +573,20 @@ For the canonical Plano Kubernetes deployment (ConfigMap, Secrets, Deployment YA
 `demo README <https://github.com/katanemo/plano/tree/main/demos/llm_routing/model_routing_service/README.md>`_.
 
 
+.. _route_on_user_only:
+
+Route on user turn only
+-----------------------
+
+When disabled (default), every LLM request is routed independently. When enabled, the router selects a model only at the start of a new user turn, and all subsequent requests within the same agentic loop are pinned to that model.
+
+.. code-block:: yaml
+
+    routing:
+      route_on_user_only: true
+
+Default: ``false``.
+
 .. _model_affinity:
 
 Model Affinity
@@ -607,8 +621,6 @@ Without the header, routing runs fresh on every request — no behavior change f
     routing:
       session_ttl_seconds: 600    # How long affinity lasts (default: 10 min)
       session_max_entries: 10000  # Max cached sessions (upper limit: 10000)
-      # Opt-in: route only on a user turn; replay the prior model otherwise.
-      # route_on_user_only: true
 
 To start a new routing decision (e.g., when the agent's task changes), generate a new affinity ID.
 

--- a/docs/source/guides/llm_router.rst
+++ b/docs/source/guides/llm_router.rst
@@ -608,7 +608,7 @@ Without the header, routing runs fresh on every request — no behavior change f
       session_ttl_seconds: 600    # How long affinity lasts (default: 10 min)
       session_max_entries: 10000  # Max cached sessions (upper limit: 10000)
       # Opt-in: route only on a user turn; replay the prior model otherwise.
-      # auto_pin_tool_calls: true
+      # route_on_user_only: true
 
 To start a new routing decision (e.g., when the agent's task changes), generate a new affinity ID.
 

--- a/docs/source/guides/llm_router.rst
+++ b/docs/source/guides/llm_router.rst
@@ -607,6 +607,8 @@ Without the header, routing runs fresh on every request — no behavior change f
     routing:
       session_ttl_seconds: 600    # How long affinity lasts (default: 10 min)
       session_max_entries: 10000  # Max cached sessions (upper limit: 10000)
+      # Opt-in: route only on a user turn; replay the prior model otherwise.
+      # route_on_user_turn: true
 
 To start a new routing decision (e.g., when the agent's task changes), generate a new affinity ID.
 

--- a/docs/source/resources/includes/plano_config_full_reference.yaml
+++ b/docs/source/resources/includes/plano_config_full_reference.yaml
@@ -223,7 +223,7 @@ routing:
   session_max_entries: 10000  # Max cached sessions before eviction (upper limit: 10000)
   # Opt-in: route only on a trailing user message; replay the prior decision on
   # tool results / assistant steps. Default false.
-  # route_on_user_turn: true
+  # auto_pin_tool_calls: true
   # session_cache controls the backend used to store affinity state.
   # "memory" (default) is in-process and works for single-instance deployments.
   # "redis" shares state across replicas — required for multi-replica / Kubernetes setups.

--- a/docs/source/resources/includes/plano_config_full_reference.yaml
+++ b/docs/source/resources/includes/plano_config_full_reference.yaml
@@ -221,6 +221,9 @@ overrides:
 routing:
   session_ttl_seconds: 600    # How long a pinned session lasts (default: 600s / 10 min)
   session_max_entries: 10000  # Max cached sessions before eviction (upper limit: 10000)
+  # Opt-in: route only on a trailing user message; replay the prior decision on
+  # tool results / assistant steps. Default false.
+  # route_on_user_turn: true
   # session_cache controls the backend used to store affinity state.
   # "memory" (default) is in-process and works for single-instance deployments.
   # "redis" shares state across replicas — required for multi-replica / Kubernetes setups.

--- a/docs/source/resources/includes/plano_config_full_reference.yaml
+++ b/docs/source/resources/includes/plano_config_full_reference.yaml
@@ -223,7 +223,7 @@ routing:
   session_max_entries: 10000  # Max cached sessions before eviction (upper limit: 10000)
   # Opt-in: route only on a trailing user message; replay the prior decision on
   # tool results / assistant steps. Default false.
-  # auto_pin_tool_calls: true
+  # route_on_user_only: true
   # session_cache controls the backend used to store affinity state.
   # "memory" (default) is in-process and works for single-instance deployments.
   # "redis" shares state across replicas — required for multi-replica / Kubernetes setups.


### PR DESCRIPTION
## Problem

A coding agent answers one user turn with many LLM calls: the model replies with tool calls, the client runs them and posts results back for the next step. Every one of those steps re-entered quality routing, so a single turn could drift across models mid-generation.

That breaks the client — tool-call ids, reasoning state and the provider prompt cache all belong to the model that started the turn. Claude Code can't work around it: it never sends `X-Model-Affinity`, so the fix has to be server-side.

```text
before: user -> route -> model A -> tool result -> route -> model B  (breaks)
after:  user -> route -> model A -> tool result -> replay A          -> next user -> route again
```

This is loop-scoped reuse, not a permanent pin. A new user message always re-routes, so sequential / intent-based selection keeps working turn to turn.

**Off by default.** General Plano users keep per-request routing. IR (and anyone else who wants this) turns it on in config — no second Plano tree:

```yaml
routing:
  route_on_user_only: true
```

## Changes

**The gate** — `is_user_turn` checks only the tail of the normalized message list. A trailing `Role::User` runs the quality router; anything else (tool results, assistant steps, empty history) replays the prior decision. That is simpler and more robust than detecting a tool loop: sequential handoff happens when the user speaks again, including Anthropic packing new user text alongside `tool_result` (that normalizes to a trailing user message).

A trailing user message also has to carry something a user actually said. Claude Code injects `<system-reminder>` and `<user-prompt-submit-hook>` blocks as user-role text, and empty user content is reachable on every client API, so those envelopes are stripped and an empty remainder counts as harness output rather than an utterance. An uncaptioned attachment is real input and does route. ReAct-style `Observation:` text remains a known limitation — it is indistinguishable from user prose without string-matching a framework convention, so it re-routes.

**Opt-in** — both the proxy (`llm/mod.rs` Phase 3) and the decision endpoint (`routing_service.rs`) call `should_reuse_prior_decision(route_on_user_only, messages)`. When the flag is false, the router runs on every request. When true, a non-user tail replays the prior model and skips `router_chat_get_upstream_model`. It still calls `session_router::route`, so warmth, history and cost bookkeeping stay correct; the router sees the anchor as its own candidate and records no switch.

**Storage** — the implicit session key is derived for this path only when `route_on_user_only` is on *and* routing preferences can override the client model (plus the existing `prompt_caching` / `routing_budget` cases). Without a session key there is nowhere to store the decision on the default Claude Code path, and the request `model` field is the wrong fallback since clients never echo the routing override.

**Lane guard** — `SessionBinding` gains `requested_model`, recording what the client asked for. Reuse requires the lane to match, so Claude Code's `ANTHROPIC_SMALL_FAST_MODEL` side calls can't inherit the main loop's model even when they share a prompt prefix. This generalizes to any multi-lane client instead of hardcoding the `arch.claude.code.small.fast` alias. The lane is the alias-resolved model on both paths: the decision endpoint was using the raw request model, so with `model_aliases` configured it wrote bindings under the alias while the proxy read them under the target, and every step re-routed.

**Normalization** — the gate reads the normalized message list, so a client API that silently drops content changes routing. Bedrock Converse did: `get_messages` discarded `toolUse` and `toolResult` blocks, so a Bedrock tool step looked like a plain user message and re-routed every step, and dropped `image` blocks made an attachment-only turn normalize to empty text. Bedrock messages now split `toolResult` into `Role::Tool` messages, attach `toolUse` to the assistant as `tool_calls`, and carry images as `ContentPart::ImageUrl` — through the same helper the Anthropic path already used, so both providers normalize identically.

Reuse is declined — falling back to a normal route — on a cold session, a drifted prompt prefix, a different lane, or no session key (`X-Plano-Cache: off`). Every ambiguous case re-routes rather than risk a wrong pin.

Observable via the `plano.routing.skipped` span attribute (`not_user_turn`) and the `brightstaff_router_skips_total` counter.

**Also in this PR** — Responses compatibility, needed to test Codex locally:

- `tools[].type = "namespace"` is accepted, and null tool fields are omitted (OpenAI rejects `tools[].domains: null`)
- Responses `input` items dispatch on the `type` discriminator, so a coincidental `id` can no longer steal `function_call` / `function_call_output` into `ItemReference`
- `custom_tool_call` / `custom_tool_call_output` are first-class items, mapping to an assistant `tool_calls` entry and a `Role::Tool` message. Codex registers custom tools by default, so without this every Codex step normalized to a trailing user message and re-routed
- Reasoning items no longer emit `summary` / `content` when the client didn't send them: a reasoning item is opaque provider state the passthrough re-serializes verbatim, and adding keys can invalidate it (@nehcgs)
- A known tool-call type that fails its typed shape (a `function_call` with no `arguments`) is still dropped for Chat Completions, but now logged, since its `function_call_output` is left orphaned upstream (@nehcgs)
- Streaming Responses echoes the served model in its lifecycle events instead of `unknown`

## Tests

Driven through the real client-API parsers rather than hand-built message structs — the claim under test is that all three wire formats normalize to a trailing user / non-user role, so hand-building would assume the thing being verified.

- All three APIs skip routing on a tool / assistant tail *when the flag is on*
- Flag off: a tool tail does not skip (general Plano unchanged)
- Fresh user turns still route, including a packed Anthropic `tool_result` + new user text
- Empty and envelope-only user tails do not route, and an uncaptioned attachment does — checked on Chat Completions, Anthropic and Bedrock Converse
- A Codex `custom_tool_call_output` tail is a continuation, not a user turn
- A model alias resolves to its target before becoming the session lane
- Bedrock `toolUse` / `toolResult` survive normalization and round-trip back; an image round-trips as a data URL
- A malformed `function_call` degrades to a dropped item instead of failing the parse, and reasoning items don't invent absent arrays (@nehcgs)
- Replay works, including when no route matched on the first turn
- Haiku lane, cold miss, prefix drift and cache-off all fall back to routing
- Skipping the router does not skip session bookkeeping
- `routing.route_on_user_only` parses as a bool; absent / false is off, true is on

## Notes for review

- `docs/routing-api.md` claimed affinity "returns the cached model without re-running routing," which the code never did. Rewritten to describe user-turn replay, and `pinned` corrected to mean the session was warm.
- The Claude Code demo config sets `routing.route_on_user_only: true`. Stock configs do not.
- One shared `X-Model-Affinity` id is not enough for a client that makes side calls (a side chat, a summarizer, a subagent). A session key holds a single binding, so whichever lane ran last owns it: the lane and prefix guards keep the side call from being *pinned* to the main loop's model, but the loop's own pin is evicted and its next continuation re-routes. Implicit affinity is unaffected, since a side call's different system prompt derives its own key. Documented as one id per conversation, not one per client session. Keying bindings by `(session_id, requested_model)` so lanes coexist is deferred to a separate PR — it changes the cache-key shape and grows entries per session.
- Not covered: an end-to-end assertion that the orchestrator receives zero HTTP calls during a live Claude Code loop. That path has no test harness in the repo, so it needs a manual run against the demo config.
