### PR TITLE
Add per-request max_switch_spend_pct header for routing budget

### DIFF
--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -565,14 +565,15 @@ properties:
           max_switch_spend_pct:
             type: number
             minimum: 0
+            maximum: 100
             description: >
               Cap on cumulative switching spend, as a percentage of what the session
-              would have cost by never switching (a whole number: 20 = 20%). The promise
-              is "this conversation bills at most max_switch_spend_pct% above never-switching."
-              0 means never pay to switch (only outright-cheaper switches are allowed);
-              larger values buy more quality-driven switches. Typical range 10-30. When
-              omitted, defaults to 20. Per-request overrides may be sent via the
-              x-routing-max-switch-spend-pct request header.
+              would have cost by never switching (e.g. 20 = 20%, max 100 = most permissive).
+              The promise is "this conversation bills at most max_switch_spend_pct% above
+              never-switching." 0 means never pay to switch (only outright-cheaper switches
+              are allowed); larger values buy more quality-driven switches. Typical range
+              10-30. When omitted, defaults to 20. Per-request overrides may be sent via
+              the x-routing-max-switch-spend-pct request header (same 0-100 range).
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -572,7 +572,7 @@ properties:
               0 means never pay to switch (only outright-cheaper switches are allowed);
               larger values buy more quality-driven switches. Typical range 10-30. When
               omitted, defaults to 20. Per-request overrides may be sent via the
-              x-plano-max-switch-spend-pct request header (alias max_switch_spend_pct).
+              x-routing-max-switch-spend-pct request header (alias max_switch_spend_pct).
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -572,8 +572,8 @@ properties:
               The promise is "this conversation bills at most max_switch_spend_pct% above
               never-switching." 0 means never pay to switch (only outright-cheaper switches
               are allowed); larger values buy more quality-driven switches. Typical range
-              10-30. When omitted, defaults to 20. Per-request overrides may be sent via
-              the x-plano-max-switch-spend-pct request header (same 0-100 range).
+              10-30. Per-request overrides may be sent via the x-plano-max-switch-spend-pct
+              request header (same 0-100 range).
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."
@@ -592,6 +592,7 @@ properties:
               the switch been allowed, as the plano.switch.counterfactual_route span
               attribute. Telemetry only — the counterfactual model is never dispatched.
               Useful for evals/benchmarks. Default false.
+        required: ["max_switch_spend_pct"]
         additionalProperties: false
     additionalProperties: false
   state_storage:

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -570,7 +570,9 @@ properties:
               would have cost by never switching (a whole number: 20 = 20%). The promise
               is "this conversation bills at most max_switch_spend_pct% above never-switching."
               0 means never pay to switch (only outright-cheaper switches are allowed);
-              larger values buy more quality-driven switches. Typical range 10-30.
+              larger values buy more quality-driven switches. Typical range 10-30. When
+              omitted, defaults to 20. Per-request overrides may be sent via the
+              x-plano-max-switch-spend-pct request header (alias max_switch_spend_pct).
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."
@@ -589,7 +591,6 @@ properties:
               the switch been allowed, as the plano.switch.counterfactual_route span
               attribute. Telemetry only — the counterfactual model is never dispatched.
               Useful for evals/benchmarks. Default false.
-        required: ["max_switch_spend_pct"]
         additionalProperties: false
     additionalProperties: false
   state_storage:

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -573,7 +573,7 @@ properties:
               never-switching." 0 means never pay to switch (only outright-cheaper switches
               are allowed); larger values buy more quality-driven switches. Typical range
               10-30. When omitted, defaults to 20. Per-request overrides may be sent via
-              the x-routing-max-switch-spend-pct request header (same 0-100 range).
+              the x-plano-max-switch-spend-pct request header (same 0-100 range).
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -572,7 +572,7 @@ properties:
               0 means never pay to switch (only outright-cheaper switches are allowed);
               larger values buy more quality-driven switches. Typical range 10-30. When
               omitted, defaults to 20. Per-request overrides may be sent via the
-              x-routing-max-switch-spend-pct request header (alias max_switch_spend_pct).
+              x-routing-max-switch-spend-pct request header.
           replenish_on_rebind:
             type: boolean
             description: "Reset the running baseline/spend totals when a cold session re-binds. Default true."

--- a/crates/brightstaff/src/handlers/llm/mod.rs
+++ b/crates/brightstaff/src/handlers/llm/mod.rs
@@ -29,6 +29,7 @@ use crate::app_state::AppState;
 use crate::handlers::agents::pipeline::PipelineProcessor;
 use crate::handlers::extract_request_id;
 use crate::handlers::full;
+use crate::handlers::routing_budget_request;
 use crate::metrics as bs_metrics;
 use crate::state::response_state_processor::ResponsesStateProcessor;
 use crate::state::{
@@ -309,7 +310,8 @@ async fn llm_chat_inner(
     // the same bytes the provider's prompt cache is keyed on. The prefix hash is
     // derived even when caching is off, so the `x-plano-prefix-hash` RING_HASH
     // replica-stickiness header still works.
-    let routing_budget = state.routing_budget;
+    let routing_budget =
+        routing_budget_request::routing_budget_for_request(state.routing_budget, &request_headers);
     // Derive the implicit session key when either prompt-caching affinity or the
     // routing budget is active — the budget needs a session anchor even with caching off.
     let implicit_affinity_enabled = prompt_caching.session_affinity || routing_budget.is_some();
@@ -453,8 +455,7 @@ async fn llm_chat_inner(
     } else {
         None
     };
-    let cache_read_discount = state
-        .routing_budget
+    let cache_read_discount = routing_budget
         .as_ref()
         .map(|b| b.cache_read_discount)
         .unwrap_or(common::configuration::DEFAULT_CACHE_READ_DISCOUNT);

--- a/crates/brightstaff/src/handlers/mod.rs
+++ b/crates/brightstaff/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod function_calling;
 pub mod llm;
 pub mod models;
 pub mod response;
+pub mod routing_budget_request;
 pub mod routing_service;
 
 #[cfg(test)]

--- a/crates/brightstaff/src/handlers/routing_budget_request.rs
+++ b/crates/brightstaff/src/handlers/routing_budget_request.rs
@@ -46,6 +46,26 @@ mod tests {
     }
 
     #[test]
+    fn header_out_of_range_is_ignored() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            HeaderValue::from_static("101"),
+        );
+        assert_eq!(max_switch_spend_pct_from_headers(&headers), None);
+    }
+
+    #[test]
+    fn header_accepts_fraction_within_range() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            HeaderValue::from_static("12.5"),
+        );
+        assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(12.5));
+    }
+
+    #[test]
     fn header_overrides_configured_budget() {
         let base = EffectiveRoutingBudget {
             max_switch_spend_pct: 20.0,

--- a/crates/brightstaff/src/handlers/routing_budget_request.rs
+++ b/crates/brightstaff/src/handlers/routing_budget_request.rs
@@ -1,0 +1,79 @@
+use common::configuration::EffectiveRoutingBudget;
+use common::consts::{MAX_SWITCH_SPEND_PCT_HEADER_ALIAS, PLANO_MAX_SWITCH_SPEND_PCT_HEADER};
+use hyper::header::HeaderMap;
+use tracing::warn;
+
+/// Read `x-plano-max-switch-spend-pct` or the `max_switch_spend_pct` alias from request headers.
+pub fn max_switch_spend_pct_from_headers(headers: &HeaderMap) -> Option<f64> {
+    for name in [
+        PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+        MAX_SWITCH_SPEND_PCT_HEADER_ALIAS,
+    ] {
+        let Some(raw) = headers.get(name).and_then(|h| h.to_str().ok()) else {
+            continue;
+        };
+        match EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value(raw) {
+            Some(pct) => return Some(pct),
+            None => {
+                warn!(
+                    header = name,
+                    value = raw,
+                    "ignoring invalid max_switch_spend_pct header value"
+                );
+            }
+        }
+    }
+    None
+}
+
+/// Instance routing budget with an optional per-request `max_switch_spend_pct` override.
+pub fn routing_budget_for_request(
+    base: Option<EffectiveRoutingBudget>,
+    headers: &HeaderMap,
+) -> Option<EffectiveRoutingBudget> {
+    EffectiveRoutingBudget::for_request(base, max_switch_spend_pct_from_headers(headers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::header::HeaderValue;
+
+    #[test]
+    fn parses_canonical_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+            HeaderValue::from_static("15"),
+        );
+        assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(15.0));
+    }
+
+    #[test]
+    fn parses_alias_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            MAX_SWITCH_SPEND_PCT_HEADER_ALIAS,
+            HeaderValue::from_static("12.5"),
+        );
+        assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(12.5));
+    }
+
+    #[test]
+    fn header_overrides_configured_budget() {
+        let base = EffectiveRoutingBudget {
+            max_switch_spend_pct: 20.0,
+            replenish_on_rebind: true,
+            cache_read_discount: 0.1,
+            record_counterfactual: true,
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+            HeaderValue::from_static("5"),
+        );
+        let resolved = routing_budget_for_request(Some(base), &headers).unwrap();
+        assert_eq!(resolved.max_switch_spend_pct, 5.0);
+        assert!(resolved.record_counterfactual);
+    }
+}

--- a/crates/brightstaff/src/handlers/routing_budget_request.rs
+++ b/crates/brightstaff/src/handlers/routing_budget_request.rs
@@ -1,18 +1,18 @@
 use common::configuration::EffectiveRoutingBudget;
-use common::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER;
+use common::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER;
 use hyper::header::HeaderMap;
 use tracing::warn;
 
-/// Read `x-routing-max-switch-spend-pct` from request headers.
+/// Read `x-plano-max-switch-spend-pct` from request headers.
 pub fn max_switch_spend_pct_from_headers(headers: &HeaderMap) -> Option<f64> {
     let raw = headers
-        .get(ROUTING_MAX_SWITCH_SPEND_PCT_HEADER)
+        .get(PLANO_MAX_SWITCH_SPEND_PCT_HEADER)
         .and_then(|h| h.to_str().ok())?;
     match EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value(raw) {
         Some(pct) => Some(pct),
         None => {
             warn!(
-                header = ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+                header = PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
                 value = raw,
                 "ignoring invalid max_switch_spend_pct header value"
             );
@@ -32,14 +32,14 @@ pub fn routing_budget_for_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER;
+    use common::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER;
     use hyper::header::HeaderValue;
 
     #[test]
     fn parses_canonical_header() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("15"),
         );
         assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(15.0));
@@ -49,7 +49,7 @@ mod tests {
     fn header_out_of_range_is_ignored() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("101"),
         );
         assert_eq!(max_switch_spend_pct_from_headers(&headers), None);
@@ -59,7 +59,7 @@ mod tests {
     fn header_accepts_fraction_within_range() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("12.5"),
         );
         assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(12.5));
@@ -75,7 +75,7 @@ mod tests {
         };
         let mut headers = HeaderMap::new();
         headers.insert(
-            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("5"),
         );
         let resolved = routing_budget_for_request(Some(base), &headers).unwrap();

--- a/crates/brightstaff/src/handlers/routing_budget_request.rs
+++ b/crates/brightstaff/src/handlers/routing_budget_request.rs
@@ -1,12 +1,12 @@
 use common::configuration::EffectiveRoutingBudget;
-use common::consts::{MAX_SWITCH_SPEND_PCT_HEADER_ALIAS, PLANO_MAX_SWITCH_SPEND_PCT_HEADER};
+use common::consts::{MAX_SWITCH_SPEND_PCT_HEADER_ALIAS, ROUTING_MAX_SWITCH_SPEND_PCT_HEADER};
 use hyper::header::HeaderMap;
 use tracing::warn;
 
-/// Read `x-plano-max-switch-spend-pct` or the `max_switch_spend_pct` alias from request headers.
+/// Read `x-routing-max-switch-spend-pct` or the `max_switch_spend_pct` alias from request headers.
 pub fn max_switch_spend_pct_from_headers(headers: &HeaderMap) -> Option<f64> {
     for name in [
-        PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+        ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
         MAX_SWITCH_SPEND_PCT_HEADER_ALIAS,
     ] {
         let Some(raw) = headers.get(name).and_then(|h| h.to_str().ok()) else {
@@ -43,7 +43,7 @@ mod tests {
     fn parses_canonical_header() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("15"),
         );
         assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(15.0));
@@ -69,7 +69,7 @@ mod tests {
         };
         let mut headers = HeaderMap::new();
         headers.insert(
-            PLANO_MAX_SWITCH_SPEND_PCT_HEADER,
+            ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
             HeaderValue::from_static("5"),
         );
         let resolved = routing_budget_for_request(Some(base), &headers).unwrap();

--- a/crates/brightstaff/src/handlers/routing_budget_request.rs
+++ b/crates/brightstaff/src/handlers/routing_budget_request.rs
@@ -1,29 +1,24 @@
 use common::configuration::EffectiveRoutingBudget;
-use common::consts::{MAX_SWITCH_SPEND_PCT_HEADER_ALIAS, ROUTING_MAX_SWITCH_SPEND_PCT_HEADER};
+use common::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER;
 use hyper::header::HeaderMap;
 use tracing::warn;
 
-/// Read `x-routing-max-switch-spend-pct` or the `max_switch_spend_pct` alias from request headers.
+/// Read `x-routing-max-switch-spend-pct` from request headers.
 pub fn max_switch_spend_pct_from_headers(headers: &HeaderMap) -> Option<f64> {
-    for name in [
-        ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
-        MAX_SWITCH_SPEND_PCT_HEADER_ALIAS,
-    ] {
-        let Some(raw) = headers.get(name).and_then(|h| h.to_str().ok()) else {
-            continue;
-        };
-        match EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value(raw) {
-            Some(pct) => return Some(pct),
-            None => {
-                warn!(
-                    header = name,
-                    value = raw,
-                    "ignoring invalid max_switch_spend_pct header value"
-                );
-            }
+    let raw = headers
+        .get(ROUTING_MAX_SWITCH_SPEND_PCT_HEADER)
+        .and_then(|h| h.to_str().ok())?;
+    match EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value(raw) {
+        Some(pct) => Some(pct),
+        None => {
+            warn!(
+                header = ROUTING_MAX_SWITCH_SPEND_PCT_HEADER,
+                value = raw,
+                "ignoring invalid max_switch_spend_pct header value"
+            );
+            None
         }
     }
-    None
 }
 
 /// Instance routing budget with an optional per-request `max_switch_spend_pct` override.
@@ -37,6 +32,7 @@ pub fn routing_budget_for_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use common::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER;
     use hyper::header::HeaderValue;
 
     #[test]
@@ -47,16 +43,6 @@ mod tests {
             HeaderValue::from_static("15"),
         );
         assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(15.0));
-    }
-
-    #[test]
-    fn parses_alias_header() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            MAX_SWITCH_SPEND_PCT_HEADER_ALIAS,
-            HeaderValue::from_static("12.5"),
-        );
-        assert_eq!(max_switch_spend_pct_from_headers(&headers), Some(12.5));
     }
 
     #[test]

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -15,6 +15,7 @@ use tracing::{debug, info, info_span, warn, Instrument};
 use super::extract_or_generate_traceparent;
 use crate::handlers::llm::model_selection::router_chat_get_upstream_model;
 use crate::handlers::llm::session_router;
+use crate::handlers::routing_budget_request;
 use crate::metrics as bs_metrics;
 use crate::metrics::labels as metric_labels;
 use crate::router::orchestrator::OrchestratorService;
@@ -130,6 +131,8 @@ async fn routing_decision_inner(
     routing_budget: Option<EffectiveRoutingBudget>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     set_service_name(operation_component::ROUTING);
+    let routing_budget =
+        routing_budget_request::routing_budget_for_request(routing_budget, &request_headers);
     opentelemetry::trace::get_active_span(|span| {
         for (key, value) in &custom_attrs {
             span.set_attribute(opentelemetry::KeyValue::new(key.clone(), value.clone()));

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -305,7 +305,7 @@ pub struct RoutingBudget {
     /// `0` means "never pay to switch" (only outright-cheaper switches are ever
     /// allowed); larger values buy more quality-driven switches. Typical range 10–30.
     /// When omitted, defaults to [`DEFAULT_MAX_SWITCH_SPEND_PCT`]; per-request overrides
-    /// use [`crate::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER`].
+    /// use [`crate::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER`].
     #[serde(default)]
     pub max_switch_spend_pct: Option<f64>,
     /// Reset the running baseline/spend totals when a session goes cold and re-binds
@@ -929,7 +929,8 @@ mod test {
 
     use super::{
         EffectivePromptCaching, EffectiveRoutingBudget, IntoModels, LlmProvider, LlmProviderType,
-        PromptCaching, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT, DEFAULT_MIN_PREFIX_TOKENS,
+        PromptCaching, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT, DEFAULT_MAX_SWITCH_SPEND_PCT,
+        DEFAULT_MIN_PREFIX_TOKENS,
     };
     use crate::api::open_ai::ToolType;
 

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -346,6 +346,23 @@ pub struct EffectiveRoutingBudget {
 pub const DEFAULT_CACHE_READ_DISCOUNT: f64 = 0.1;
 /// Default overhead cap when `max_switch_spend_pct` is omitted from config (20%).
 pub const DEFAULT_MAX_SWITCH_SPEND_PCT: f64 = 20.0;
+/// Inclusive bounds for `max_switch_spend_pct` (percent of never-switch baseline).
+pub const MAX_SWITCH_SPEND_PCT_MIN: f64 = 0.0;
+pub const MAX_SWITCH_SPEND_PCT_MAX: f64 = 100.0;
+
+/// Returns `Ok(())` when `pct` is a finite percent in [`MAX_SWITCH_SPEND_PCT_MIN`],
+/// [`MAX_SWITCH_SPEND_PCT_MAX`].
+pub fn validate_max_switch_spend_pct(pct: f64) -> Result<(), String> {
+    if !pct.is_finite() || !(MAX_SWITCH_SPEND_PCT_MIN..=MAX_SWITCH_SPEND_PCT_MAX).contains(&pct) {
+        return Err(format!(
+            "max_switch_spend_pct: must be a number between {} and {} (percent, e.g. 20 for 20%), got {}",
+            MAX_SWITCH_SPEND_PCT_MIN,
+            MAX_SWITCH_SPEND_PCT_MAX,
+            pct
+        ));
+    }
+    Ok(())
+}
 
 impl RoutingBudget {
     /// Resolve to effective settings, validating the overhead cap and cache-read
@@ -354,12 +371,9 @@ impl RoutingBudget {
         let max_switch_spend_pct = self
             .max_switch_spend_pct
             .unwrap_or(DEFAULT_MAX_SWITCH_SPEND_PCT);
-        if !max_switch_spend_pct.is_finite() || max_switch_spend_pct < 0.0 {
-            return Err(format!(
-                "routing.routing_budget.max_switch_spend_pct: must be a non-negative number (percent, e.g. 20 for 20%), got {}",
-                max_switch_spend_pct
-            ));
-        }
+        validate_max_switch_spend_pct(max_switch_spend_pct).map_err(|msg| {
+            format!("routing.routing_budget.{msg}")
+        })?;
         let cache_read_discount = self
             .cache_read_discount
             .unwrap_or(DEFAULT_CACHE_READ_DISCOUNT);
@@ -383,14 +397,10 @@ impl EffectiveRoutingBudget {
         config.map(RoutingBudget::resolve).transpose()
     }
 
-    /// Parse a header value (whole-number percent, e.g. `20` = 20%).
+    /// Parse a header value (percent in [`MAX_SWITCH_SPEND_PCT_MIN`], [`MAX_SWITCH_SPEND_PCT_MAX`]).
     pub fn parse_max_switch_spend_pct_header_value(raw: &str) -> Option<f64> {
         let pct = raw.trim().parse::<f64>().ok()?;
-        if pct.is_finite() && pct >= 0.0 {
-            Some(pct)
-        } else {
-            None
-        }
+        validate_max_switch_spend_pct(pct).ok().map(|()| pct)
     }
 
     /// Apply the instance config and an optional per-request header override.
@@ -1356,9 +1366,20 @@ cache_read_discount: 0.25
     }
 
     #[test]
+    fn test_routing_budget_pct_at_bounds() {
+        let at_zero: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: 0").unwrap();
+        assert_eq!(at_zero.resolve().unwrap().max_switch_spend_pct, 0.0);
+        let at_max: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: 100").unwrap();
+        assert_eq!(at_max.resolve().unwrap().max_switch_spend_pct, 100.0);
+    }
+
+    #[test]
     fn test_routing_budget_invalid_values_rejected() {
         let negative: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: -1.0").unwrap();
         assert!(negative.resolve().is_err());
+
+        let over_max: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: 100.1").unwrap();
+        assert!(over_max.resolve().is_err());
 
         let bad_discount: RoutingBudget = serde_yaml::from_str(
             r#"

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -305,7 +305,7 @@ pub struct RoutingBudget {
     /// `0` means "never pay to switch" (only outright-cheaper switches are ever
     /// allowed); larger values buy more quality-driven switches. Typical range 10–30.
     /// When omitted, defaults to [`DEFAULT_MAX_SWITCH_SPEND_PCT`]; per-request overrides
-    /// use [`crate::consts::ROUTING_MAX_SWITCH_SPEND_PCT_HEADER`].
+    /// use [`crate::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER`].
     #[serde(default)]
     pub max_switch_spend_pct: Option<f64>,
     /// Reset the running baseline/spend totals when a session goes cold and re-binds

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -1366,6 +1366,19 @@ cache_read_discount: 0.25
     }
 
     #[test]
+    fn test_max_switch_spend_pct_header_parse_respects_range() {
+        assert_eq!(
+            EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("0"),
+            Some(0.0)
+        );
+        assert_eq!(
+            EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("100"),
+            Some(100.0)
+        );
+        assert!(EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("100.01").is_none());
+    }
+
+    #[test]
     fn test_routing_budget_pct_at_bounds() {
         let at_zero: RoutingBudget = serde_yaml::from_str("max_switch_spend_pct: 0").unwrap();
         assert_eq!(at_zero.resolve().unwrap().max_switch_spend_pct, 0.0);

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -371,9 +371,8 @@ impl RoutingBudget {
         let max_switch_spend_pct = self
             .max_switch_spend_pct
             .unwrap_or(DEFAULT_MAX_SWITCH_SPEND_PCT);
-        validate_max_switch_spend_pct(max_switch_spend_pct).map_err(|msg| {
-            format!("routing.routing_budget.{msg}")
-        })?;
+        validate_max_switch_spend_pct(max_switch_spend_pct)
+            .map_err(|msg| format!("routing.routing_budget.{msg}"))?;
         let cache_read_discount = self
             .cache_read_discount
             .unwrap_or(DEFAULT_CACHE_READ_DISCOUNT);
@@ -1375,7 +1374,9 @@ cache_read_discount: 0.25
             EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("100"),
             Some(100.0)
         );
-        assert!(EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("100.01").is_none());
+        assert!(
+            EffectiveRoutingBudget::parse_max_switch_spend_pct_header_value("100.01").is_none()
+        );
     }
 
     #[test]

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -304,7 +304,10 @@ pub struct RoutingBudget {
     /// is "this conversation bills at most `max_switch_spend_pct`% above never-switching."
     /// `0` means "never pay to switch" (only outright-cheaper switches are ever
     /// allowed); larger values buy more quality-driven switches. Typical range 10–30.
-    pub max_switch_spend_pct: f64,
+    /// When omitted, defaults to [`DEFAULT_MAX_SWITCH_SPEND_PCT`]; per-request overrides
+    /// use [`crate::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER`].
+    #[serde(default)]
+    pub max_switch_spend_pct: Option<f64>,
     /// Reset the running baseline/spend totals when a session goes cold and re-binds
     /// (a fresh warm episode). Defaults to `true`.
     #[serde(default = "default_true")]
@@ -341,15 +344,20 @@ pub struct EffectiveRoutingBudget {
 }
 
 pub const DEFAULT_CACHE_READ_DISCOUNT: f64 = 0.1;
+/// Default overhead cap when `max_switch_spend_pct` is omitted from config (20%).
+pub const DEFAULT_MAX_SWITCH_SPEND_PCT: f64 = 20.0;
 
 impl RoutingBudget {
     /// Resolve to effective settings, validating the overhead cap and cache-read
     /// discount.
     pub fn resolve(&self) -> Result<EffectiveRoutingBudget, String> {
-        if !self.max_switch_spend_pct.is_finite() || self.max_switch_spend_pct < 0.0 {
+        let max_switch_spend_pct = self
+            .max_switch_spend_pct
+            .unwrap_or(DEFAULT_MAX_SWITCH_SPEND_PCT);
+        if !max_switch_spend_pct.is_finite() || max_switch_spend_pct < 0.0 {
             return Err(format!(
                 "routing.routing_budget.max_switch_spend_pct: must be a non-negative number (percent, e.g. 20 for 20%), got {}",
-                self.max_switch_spend_pct
+                max_switch_spend_pct
             ));
         }
         let cache_read_discount = self
@@ -361,7 +369,7 @@ impl RoutingBudget {
             ));
         }
         Ok(EffectiveRoutingBudget {
-            max_switch_spend_pct: self.max_switch_spend_pct,
+            max_switch_spend_pct,
             replenish_on_rebind: self.replenish_on_rebind,
             cache_read_discount,
             record_counterfactual: self.record_counterfactual,
@@ -373,6 +381,39 @@ impl EffectiveRoutingBudget {
     /// Resolve from an optional config block; `None` means the gate is off.
     pub fn from_config(config: Option<&RoutingBudget>) -> Result<Option<Self>, String> {
         config.map(RoutingBudget::resolve).transpose()
+    }
+
+    /// Parse a header value (whole-number percent, e.g. `20` = 20%).
+    pub fn parse_max_switch_spend_pct_header_value(raw: &str) -> Option<f64> {
+        let pct = raw.trim().parse::<f64>().ok()?;
+        if pct.is_finite() && pct >= 0.0 {
+            Some(pct)
+        } else {
+            None
+        }
+    }
+
+    /// Apply the instance config and an optional per-request header override.
+    ///
+    /// When the header is present it wins over the configured `max_switch_spend_pct`.
+    /// When the gate is off in config but the header is set, a budget is synthesized
+    /// with the other fields at their defaults (requires a cost metrics source at
+    /// runtime for switch-cost gating to take effect).
+    pub fn for_request(base: Option<Self>, header_pct: Option<f64>) -> Option<Self> {
+        match (base, header_pct) {
+            (None, None) => None,
+            (Some(mut cfg), Some(pct)) => {
+                cfg.max_switch_spend_pct = pct;
+                Some(cfg)
+            }
+            (Some(cfg), None) => Some(cfg),
+            (None, Some(pct)) => Some(Self {
+                max_switch_spend_pct: pct,
+                replenish_on_rebind: true,
+                cache_read_discount: DEFAULT_CACHE_READ_DISCOUNT,
+                record_counterfactual: false,
+            }),
+        }
     }
 }
 
@@ -1284,6 +1325,33 @@ cache_read_discount: 0.25
     fn test_routing_budget_absent_is_off() {
         // No block configured → gate is off.
         assert!(EffectiveRoutingBudget::from_config(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_routing_budget_empty_block_uses_default_pct() {
+        let cfg: RoutingBudget = serde_yaml::from_str("{}").unwrap();
+        let budget = cfg.resolve().unwrap();
+        assert_eq!(budget.max_switch_spend_pct, DEFAULT_MAX_SWITCH_SPEND_PCT);
+    }
+
+    #[test]
+    fn test_routing_budget_for_request_header_override() {
+        let base = EffectiveRoutingBudget {
+            max_switch_spend_pct: 20.0,
+            replenish_on_rebind: true,
+            cache_read_discount: DEFAULT_CACHE_READ_DISCOUNT,
+            record_counterfactual: false,
+        };
+        let with_header = EffectiveRoutingBudget::for_request(Some(base), Some(7.0)).unwrap();
+        assert_eq!(with_header.max_switch_spend_pct, 7.0);
+    }
+
+    #[test]
+    fn test_routing_budget_header_only_synthesizes_defaults() {
+        let cfg = EffectiveRoutingBudget::for_request(None, Some(10.0)).unwrap();
+        assert_eq!(cfg.max_switch_spend_pct, 10.0);
+        assert!(cfg.replenish_on_rebind);
+        assert_eq!(cfg.cache_read_discount, DEFAULT_CACHE_READ_DISCOUNT);
     }
 
     #[test]

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -304,10 +304,8 @@ pub struct RoutingBudget {
     /// is "this conversation bills at most `max_switch_spend_pct`% above never-switching."
     /// `0` means "never pay to switch" (only outright-cheaper switches are ever
     /// allowed); larger values buy more quality-driven switches. Typical range 10–30.
-    /// When omitted, defaults to [`DEFAULT_MAX_SWITCH_SPEND_PCT`]; per-request overrides
-    /// use [`crate::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER`].
-    #[serde(default)]
-    pub max_switch_spend_pct: Option<f64>,
+    /// Per-request overrides use [`crate::consts::PLANO_MAX_SWITCH_SPEND_PCT_HEADER`].
+    pub max_switch_spend_pct: f64,
     /// Reset the running baseline/spend totals when a session goes cold and re-binds
     /// (a fresh warm episode). Defaults to `true`.
     #[serde(default = "default_true")]
@@ -344,8 +342,6 @@ pub struct EffectiveRoutingBudget {
 }
 
 pub const DEFAULT_CACHE_READ_DISCOUNT: f64 = 0.1;
-/// Default overhead cap when `max_switch_spend_pct` is omitted from config (20%).
-pub const DEFAULT_MAX_SWITCH_SPEND_PCT: f64 = 20.0;
 /// Inclusive bounds for `max_switch_spend_pct` (percent of never-switch baseline).
 pub const MAX_SWITCH_SPEND_PCT_MIN: f64 = 0.0;
 pub const MAX_SWITCH_SPEND_PCT_MAX: f64 = 100.0;
@@ -368,9 +364,7 @@ impl RoutingBudget {
     /// Resolve to effective settings, validating the overhead cap and cache-read
     /// discount.
     pub fn resolve(&self) -> Result<EffectiveRoutingBudget, String> {
-        let max_switch_spend_pct = self
-            .max_switch_spend_pct
-            .unwrap_or(DEFAULT_MAX_SWITCH_SPEND_PCT);
+        let max_switch_spend_pct = self.max_switch_spend_pct;
         validate_max_switch_spend_pct(max_switch_spend_pct)
             .map_err(|msg| format!("routing.routing_budget.{msg}"))?;
         let cache_read_discount = self
@@ -938,8 +932,7 @@ mod test {
 
     use super::{
         EffectivePromptCaching, EffectiveRoutingBudget, IntoModels, LlmProvider, LlmProviderType,
-        PromptCaching, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT, DEFAULT_MAX_SWITCH_SPEND_PCT,
-        DEFAULT_MIN_PREFIX_TOKENS,
+        PromptCaching, RoutingBudget, DEFAULT_CACHE_READ_DISCOUNT, DEFAULT_MIN_PREFIX_TOKENS,
     };
     use crate::api::open_ai::ToolType;
 
@@ -1338,10 +1331,9 @@ cache_read_discount: 0.25
     }
 
     #[test]
-    fn test_routing_budget_empty_block_uses_default_pct() {
-        let cfg: RoutingBudget = serde_yaml::from_str("{}").unwrap();
-        let budget = cfg.resolve().unwrap();
-        assert_eq!(budget.max_switch_spend_pct, DEFAULT_MAX_SWITCH_SPEND_PCT);
+    fn test_routing_budget_missing_pct_rejected() {
+        let err = serde_yaml::from_str::<RoutingBudget>("{}");
+        assert!(err.is_err());
     }
 
     #[test]

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -29,9 +29,9 @@ pub const PLANO_CACHE_HEADER: &str = "x-plano-cache";
 /// Hash of the stable prompt prefix, forwarded upstream so self-hosted multi-replica
 /// backends can do KV-aware (consistent-hash) replica routing at the LB/Envoy layer.
 pub const PLANO_PREFIX_HASH_HEADER: &str = "x-plano-prefix-hash";
-/// Per-request override for `routing.routing_budget.max_switch_spend_pct` (whole number,
+/// Per-request override for `routing.routing_budget.max_switch_spend_pct` (0–100,
 /// e.g. `20` = 20%). When absent, the configured default applies.
-pub const ROUTING_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-routing-max-switch-spend-pct";
+pub const PLANO_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-plano-max-switch-spend-pct";
 pub const ENVOY_ORIGINAL_PATH_HEADER: &str = "x-envoy-original-path";
 pub const TRACE_PARENT_HEADER: &str = "traceparent";
 pub const ARCH_INTERNAL_CLUSTER_NAME: &str = "arch_internal";

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -29,6 +29,11 @@ pub const PLANO_CACHE_HEADER: &str = "x-plano-cache";
 /// Hash of the stable prompt prefix, forwarded upstream so self-hosted multi-replica
 /// backends can do KV-aware (consistent-hash) replica routing at the LB/Envoy layer.
 pub const PLANO_PREFIX_HASH_HEADER: &str = "x-plano-prefix-hash";
+/// Per-request override for `routing.routing_budget.max_switch_spend_pct` (whole number,
+/// e.g. `20` = 20%). When absent, the configured default applies.
+pub const PLANO_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-plano-max-switch-spend-pct";
+/// Alias for [`PLANO_MAX_SWITCH_SPEND_PCT_HEADER`] (field name forwarded by some proxies).
+pub const MAX_SWITCH_SPEND_PCT_HEADER_ALIAS: &str = "max_switch_spend_pct";
 pub const ENVOY_ORIGINAL_PATH_HEADER: &str = "x-envoy-original-path";
 pub const TRACE_PARENT_HEADER: &str = "traceparent";
 pub const ARCH_INTERNAL_CLUSTER_NAME: &str = "arch_internal";

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -32,8 +32,6 @@ pub const PLANO_PREFIX_HASH_HEADER: &str = "x-plano-prefix-hash";
 /// Per-request override for `routing.routing_budget.max_switch_spend_pct` (whole number,
 /// e.g. `20` = 20%). When absent, the configured default applies.
 pub const ROUTING_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-routing-max-switch-spend-pct";
-/// Alias (field name forwarded by some proxies).
-pub const MAX_SWITCH_SPEND_PCT_HEADER_ALIAS: &str = "max_switch_spend_pct";
 pub const ENVOY_ORIGINAL_PATH_HEADER: &str = "x-envoy-original-path";
 pub const TRACE_PARENT_HEADER: &str = "traceparent";
 pub const ARCH_INTERNAL_CLUSTER_NAME: &str = "arch_internal";

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -31,8 +31,8 @@ pub const PLANO_CACHE_HEADER: &str = "x-plano-cache";
 pub const PLANO_PREFIX_HASH_HEADER: &str = "x-plano-prefix-hash";
 /// Per-request override for `routing.routing_budget.max_switch_spend_pct` (whole number,
 /// e.g. `20` = 20%). When absent, the configured default applies.
-pub const PLANO_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-plano-max-switch-spend-pct";
-/// Alias for [`PLANO_MAX_SWITCH_SPEND_PCT_HEADER`] (field name forwarded by some proxies).
+pub const ROUTING_MAX_SWITCH_SPEND_PCT_HEADER: &str = "x-routing-max-switch-spend-pct";
+/// Alias (field name forwarded by some proxies).
 pub const MAX_SWITCH_SPEND_PCT_HEADER_ALIAS: &str = "max_switch_spend_pct";
 pub const ENVOY_ORIGINAL_PATH_HEADER: &str = "x-envoy-original-path";
 pub const TRACE_PARENT_HEADER: &str = "traceparent";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **`x-routing-max-switch-spend-pct`** (alias **`max_switch_spend_pct`**) so callers can override `routing.routing_budget.max_switch_spend_pct` per request on the LLM proxy and routing-decision paths.
- Makes `max_switch_spend_pct` optional in config (defaults to **20%** when `routing_budget` is present); the header wins when set.
- If routing budget is not configured in YAML but the header is present, a one-off effective budget is synthesized with default replenish/cache-read settings (still needs a cost metrics source for gating to work).

## Behavior

| Header | Config `routing_budget` | Result |
|--------|-------------------------|--------|
| absent | absent | Budget off |
| absent | present | Config cap (default 20% if omitted) |
| present | present | Header cap |
| present | absent | Header cap with default side settings |

Invalid header values are logged and ignored (config/default applies).

## Test plan

- [ ] `cargo test --lib -p common -p brightstaff` (routing budget + header parsing tests)
- [ ] Manual: `routing_budget: {}` in config + `x-routing-max-switch-spend-pct: 5` on a session with affinity; verify switch veto/allow vs baseline

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://digitalocean.slack.com/archives/C0BEDCC09NG/p1786140857862889?thread_ts=1786140857.862889&cid=C0BEDCC09NG)

<div><a href="https://cursor.com/agents/bc-bec73235-84e7-579e-9590-5d0cf73c71c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bec73235-84e7-579e-9590-5d0cf73c71c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

