### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -34,6 +34,7 @@ SUPPORTED_PROVIDERS_WITHOUT_BASE_URL = [
     "vercel",
     "openrouter",
     "edenai",
+    "orcarouter",
 ]
 
 CHATGPT_API_BASE = "https://chatgpt.com/backend-api/codex"

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -96,6 +96,16 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         base_url="https://openrouter.ai/api/v1",
         model_pattern="openrouter/*",
     ),
+    # OrcaRouter is an OpenAI-compatible meta-router/gateway routing to many
+    # upstream models behind one key — same treatment as OpenRouter, no
+    # provider_interface override needed. Model ids are namespaced upstream
+    # (e.g. `orcarouter/openai/gpt-5.5` or `orcarouter/orcarouter/auto`).
+    ProviderDefault(
+        name="orcarouter",
+        env_var="ORCAROUTER_API_KEY",
+        base_url="https://api.orcarouter.ai/v1",
+        model_pattern="orcarouter/*",
+    ),
     # Eden AI is an EU-based, OpenAI-compatible gateway routing to many upstream
     # providers behind one key — same treatment as OpenRouter, no
     # provider_interface override needed.

--- a/cli/test/test_config_generator.py
+++ b/cli/test/test_config_generator.py
@@ -316,6 +316,24 @@ model_providers:
 """,
     },
     {
+        "id": "orcarouter_is_supported_provider",
+        "expected_error": None,
+        "plano_config": """
+version: v0.4.0
+
+listeners:
+  - name: llm
+    type: model
+    port: 12000
+
+model_providers:
+  - model: orcarouter/*
+    base_url: https://api.orcarouter.ai/v1
+    passthrough_auth: true
+
+""",
+    },
+    {
         "id": "duplicate_routeing_preference_name",
         "expected_error": "Duplicate routing preference name",
         "plano_config": """

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -30,6 +30,7 @@ def test_zero_env_vars_produces_pure_passthrough():
     assert "digitalocean" in names
     assert "vercel" in names
     assert "openrouter" in names
+    assert "orcarouter" in names
     assert "edenai" in names
     assert "openai" in names
     assert "anthropic" in names

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -49,6 +49,7 @@ pub enum ProviderId {
     DigitalOcean,
     Vercel,
     OpenRouter,
+    OrcaRouter,
     Astraflow,
     AstraflowCN,
     Meta,
@@ -87,6 +88,7 @@ impl TryFrom<&str> for ProviderId {
             "do_ai" => Ok(ProviderId::DigitalOcean), // alias
             "vercel" => Ok(ProviderId::Vercel),
             "openrouter" => Ok(ProviderId::OpenRouter),
+            "orcarouter" => Ok(ProviderId::OrcaRouter),
             "astraflow" => Ok(ProviderId::Astraflow),
             "astraflow_cn" => Ok(ProviderId::AstraflowCN),
             "meta" => Ok(ProviderId::Meta),
@@ -155,7 +157,10 @@ fn model_family(model_name: &str) -> ModelFamily {
 fn accepts_openai_content_part_cache_control(provider: ProviderId) -> bool {
     matches!(
         provider,
-        ProviderId::DigitalOcean | ProviderId::OpenRouter | ProviderId::EdenAI
+        ProviderId::DigitalOcean
+            | ProviderId::OpenRouter
+            | ProviderId::OrcaRouter
+            | ProviderId::EdenAI
     )
 }
 
@@ -174,6 +179,7 @@ fn is_automatic_cache_provider(provider: ProviderId) -> bool {
             | ProviderId::XAI
             | ProviderId::DigitalOcean
             | ProviderId::OpenRouter
+            | ProviderId::OrcaRouter
             | ProviderId::EdenAI
     )
 }
@@ -272,6 +278,7 @@ pub fn provider_cache_capability(provider: ProviderId) -> ProviderCacheCapabilit
         ProviderId::Anthropic
         | ProviderId::DigitalOcean
         | ProviderId::OpenRouter
+        | ProviderId::OrcaRouter
         | ProviderId::EdenAI
         | ProviderId::Vercel => ProviderCacheCapability::default(),
         // OpenAI-family automatic prefix caching also lives on the order of minutes;
@@ -379,6 +386,7 @@ impl ProviderId {
                 | ProviderId::Qwen
                 | ProviderId::DigitalOcean
                 | ProviderId::OpenRouter
+                | ProviderId::OrcaRouter
                 | ProviderId::ChatGPT
                 | ProviderId::Astraflow
                 | ProviderId::AstraflowCN
@@ -406,6 +414,7 @@ impl ProviderId {
                 | ProviderId::Qwen
                 | ProviderId::DigitalOcean
                 | ProviderId::OpenRouter
+                | ProviderId::OrcaRouter
                 | ProviderId::ChatGPT
                 | ProviderId::Astraflow
                 | ProviderId::AstraflowCN
@@ -482,6 +491,7 @@ impl Display for ProviderId {
             ProviderId::DigitalOcean => write!(f, "digitalocean"),
             ProviderId::Vercel => write!(f, "vercel"),
             ProviderId::OpenRouter => write!(f, "openrouter"),
+            ProviderId::OrcaRouter => write!(f, "orcarouter"),
             ProviderId::Astraflow => write!(f, "astraflow"),
             ProviderId::AstraflowCN => write!(f, "astraflow_cn"),
             ProviderId::Meta => write!(f, "meta"),
@@ -530,6 +540,33 @@ mod tests {
             strategy,
             CacheMarkerStrategy::OpenAiContentPartCacheControl { .. }
         ));
+    }
+
+    #[test]
+    fn orcarouter_anthropic_uses_openai_content_part_markers() {
+        // OrcaRouter is an OpenAI-compatible gateway like OpenRouter; Anthropic-family
+        // models over its chat-completions endpoint get content-part cache markers.
+        let strategy = cache_marker_strategy(
+            ProviderId::OrcaRouter,
+            "anthropic/claude-3.5-sonnet",
+            &chat_completions(),
+        );
+        assert!(matches!(
+            strategy,
+            CacheMarkerStrategy::OpenAiContentPartCacheControl { .. }
+        ));
+    }
+
+    #[test]
+    fn orcarouter_parses_from_str() {
+        assert_eq!(
+            ProviderId::try_from("orcarouter"),
+            Ok(ProviderId::OrcaRouter)
+        );
+        assert_eq!(
+            ProviderId::try_from("OrcaRouter").map(|p| p.to_string()),
+            Ok("orcarouter".to_string())
+        );
     }
 
     #[test]

--- a/docs/source/concepts/llm_providers/supported_providers.rst
+++ b/docs/source/concepts/llm_providers/supported_providers.rst
@@ -683,6 +683,26 @@ Ollama
         base_url: http://localhost:11434
 
 
+OrcaRouter
+~~~~~~~~~~
+
+**Provider Prefix:** ``orcarouter/``
+
+**API Endpoint:** ``/v1/chat/completions`` (OpenAI-compatible meta-router/gateway)
+
+**Authentication:** API Key - Get your OrcaRouter API key from `OrcaRouter <https://www.orcarouter.ai>`_.
+
+**Supported Chat Models:** All models routed by OrcaRouter, namespaced by upstream provider. Use the full namespaced id (e.g. ``orcarouter/openai/gpt-5.5``) or the dynamic ``orcarouter/orcarouter/auto`` route.
+
+.. code-block:: yaml
+
+    llm_providers:
+      # Route any model through OrcaRouter behind one key
+      - model: orcarouter/*
+        base_url: https://api.orcarouter.ai/v1
+        access_key: $ORCAROUTER_API_KEY
+
+
 OpenAI-Compatible Providers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/skills/rules/config-providers.md
+++ b/skills/rules/config-providers.md
@@ -21,6 +21,7 @@ Plano translates requests between its internal format and each provider's API. T
 | `deepseek/*` | DeepSeek | `deepseek/deepseek-chat` |
 | `xai/*` | Grok (OpenAI-compat) | `xai/grok-2` |
 | `together_ai/*` | Together.ai | `together_ai/meta-llama/Llama-3` |
+| `orcarouter/*` | OpenAI | `orcarouter/openai/gpt-5.5` |
 | `custom/*` | Requires `provider_interface` | `custom/my-local-model` |
 
 **Incorrect (missing provider prefix, ambiguous format):**


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class provider in Plano, mirroring how OpenRouter and EdenAI are integrated.

OrcaRouter is an OpenAI-compatible gateway that reaches 100+ model providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, Groq, and more) through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

**`ProviderId`** (`crates/hermesllm/src/providers/id.rs`)
- New `OrcaRouter` variant alongside `OpenRouter`
- `TryFrom<&str>`: `"orcarouter"` resolves to `ProviderId::OrcaRouter`
- `Display`: renders as `orcarouter`
- Prompt caching: `accepts_openai_content_part_cache_control`, `is_automatic_cache_provider`, and `provider_cache_capability` treat OrcaRouter like the other OpenAI-compatible gateways (Anthropic-family cache semantics, OpenAI content-part markers)
- `compatible_api_for_client`: OrcaRouter grouped with the OpenAI-compatible providers for both the Anthropic and OpenAI client APIs

**Python CLI** (`cli/planoai/`)
- `ProviderDefault` for `orcarouter` (`ORCAROUTER_API_KEY`, base URL `https://api.orcarouter.ai/v1`, model pattern `orcarouter/*`)
- Registered in `SUPPORTED_PROVIDERS_WITHOUT_BASE_URL`

**Docs**
- New `OrcaRouter` section in `docs/source/concepts/llm_providers/supported_providers.rst`
- New provider-format row in `skills/rules/config-providers.md`

## Tests

- `cargo test -p hermesllm --lib`: 197 passed, 0 failed (includes 2 new `orcarouter` tests)
- `cargo clippy -p hermesllm --lib`: clean
- `cargo fmt --all -- --check`: clean
- Python CLI: 40 passed

I'm an engineer on the OrcaRouter team.
