### PR TITLE
feat(hermesllm): add MiniMax M2.7 model

### DIFF
--- a/crates/hermesllm/src/bin/provider_models.yaml
+++ b/crates/hermesllm/src/bin/provider_models.yaml
@@ -129,6 +129,7 @@ providers:
   - meta/muse-spark-1.1
   minimax:
   - minimax/MiniMax-M3
+  - minimax/MiniMax-M2.7
   mistralai:
   - mistralai/mistral-medium-2505
   - mistralai/mistral-medium-2508

--- a/crates/hermesllm/src/providers/id.rs
+++ b/crates/hermesllm/src/providers/id.rs
@@ -775,6 +775,10 @@ mod tests {
             models.iter().any(|m| m == "MiniMax-M3"),
             "minimax models should include MiniMax-M3"
         );
+        assert!(
+            models.iter().any(|m| m == "MiniMax-M2.7"),
+            "minimax models should include MiniMax-M2.7"
+        );
         for model in &models {
             assert!(
                 !model.contains('/'),


### PR DESCRIPTION
Reason: MiniMax wildcard expansion does not include MiniMax-M2.7.

This adds MiniMax-M2.7 to the provider model registry and verifies that model discovery includes it.

Checks:
- `cargo test -p hermesllm`
- `cargo fmt --all -- --check`
