### PR TITLE
Add switched field to routing decision response

### DIFF
--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -254,6 +254,7 @@ pub async fn route(
     let baseline_usd;
     let mut switch_spend_usd;
     let mut switches;
+    let mut switched = false;
     let mut cost_opt: Option<f64> = None;
     let mut ceiling_opt: Option<f64> = None;
     let mut candidate_warm_tokens: u64 = 0;
@@ -333,6 +334,7 @@ pub async fn route(
                     // veto the router on guesswork.
                     None => {
                         switches += 1;
+                        switched = true;
                         decision_label = metric_labels::SWITCH_DECISION_ALLOWED;
                         reason = metric_labels::SWITCH_REASON_NO_PRICING;
                         debug!(
@@ -347,6 +349,7 @@ pub async fn route(
                             // Outright cheaper: allowed for free. Does NOT reduce spend —
                             // the "saving" is vs a path we didn't take, not real money.
                             switches += 1;
+                            switched = true;
                             decision_label = metric_labels::SWITCH_DECISION_ALLOWED;
                             reason = metric_labels::SWITCH_REASON_FREE;
                             info!(
@@ -358,6 +361,7 @@ pub async fn route(
                         } else if switch_spend_usd + cost <= ceiling {
                             switch_spend_usd += cost;
                             switches += 1;
+                            switched = true;
                             decision_label = metric_labels::SWITCH_DECISION_ALLOWED;
                             reason = metric_labels::SWITCH_REASON_WITHIN_CAP;
                             info!(
@@ -396,6 +400,7 @@ pub async fn route(
             } else {
                 // Warm but no budget configured — follow the router freely.
                 switches += 1;
+                switched = true;
                 decision_label = metric_labels::SWITCH_DECISION_ALLOWED;
                 reason = metric_labels::SWITCH_REASON_FREE;
             }
@@ -535,10 +540,6 @@ pub async fn route(
             Some(gc_ttl),
         )
         .await;
-
-    // Mirrors `plano.switch.decision` on the span: only emitted when a switch cost was
-    // evaluated, and "allowed" when the router's pick was honored.
-    let switched = cost_opt.is_some() && model == facts.candidate_model;
 
     RouteDecision {
         model,

--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -121,6 +121,9 @@ pub struct RouteDecision {
     pub default_model: String,
     /// Whether the session's cache was inferred warm at decision time.
     pub warm: bool,
+    /// Whether a model switch was allowed this turn — mirrors `plano.switch.decision=allowed`
+    /// on the span when the routing budget evaluated a switch.
+    pub switched: bool,
     /// Cumulative never-switch baseline (USD) after this decision.
     pub baseline_usd: f64,
     /// Cumulative switch spend (USD) after this decision.
@@ -212,6 +215,7 @@ pub async fn route(
             route_name: facts.candidate_route.map(str::to_string),
             default_model: facts.candidate_model.to_string(),
             warm: false,
+            switched: false,
             baseline_usd: 0.0,
             switch_spend_usd: 0.0,
             session_cost_usd: 0.0,
@@ -532,11 +536,16 @@ pub async fn route(
         )
         .await;
 
+    // Mirrors `plano.switch.decision` on the span: only emitted when a switch cost was
+    // evaluated, and "allowed" when the router's pick was honored.
+    let switched = cost_opt.is_some() && model == facts.candidate_model;
+
     RouteDecision {
         model,
         route_name,
         default_model,
         warm: effective_warm,
+        switched,
         baseline_usd,
         switch_spend_usd,
         session_cost_usd,
@@ -721,6 +730,7 @@ mod tests {
 
         assert_eq!(d.model, "openai/pricey");
         assert!(d.warm);
+        assert!(d.switched);
         assert_eq!(d.switches, 1);
         assert!(
             (d.switch_spend_usd - 0.47).abs() < 1e-6,
@@ -744,6 +754,7 @@ mod tests {
 
         assert_eq!(d.model, "anthropic/expensive");
         assert!(d.warm);
+        assert!(!d.switched);
         assert_eq!(d.switches, 0);
         // Vetoed switch spends nothing.
         assert!((d.switch_spend_usd - 0.0).abs() < 1e-6);

--- a/crates/brightstaff/src/handlers/routing_service.rs
+++ b/crates/brightstaff/src/handlers/routing_service.rs
@@ -62,6 +62,8 @@ struct RoutingDecisionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
     pinned: bool,
+    /// Whether the routing budget allowed a model switch this turn (`plano.switch.decision=allowed`).
+    switched: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -262,6 +264,7 @@ async fn routing_decision_inner(
                 // `pinned` signals a warm, stuck session — safe for callers to treat as
                 // "keep this provider's cache warm".
                 pinned: decision.warm,
+                switched: decision.switched,
             };
 
             // Distinguish "decision served" (a concrete model picked) from
@@ -280,6 +283,7 @@ async fn routing_decision_inner(
                 total_models = response.models.len(),
                 route = ?response.route,
                 pinned = response.pinned,
+                switched = response.switched,
                 "routing decision completed"
             );
 
@@ -439,6 +443,7 @@ mod tests {
             trace_id: "abc123".to_string(),
             session_id: Some("sess-abc".to_string()),
             pinned: true,
+            switched: true,
         };
         let json = serde_json::to_string(&response).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -448,6 +453,7 @@ mod tests {
         assert_eq!(parsed["trace_id"], "abc123");
         assert_eq!(parsed["session_id"], "sess-abc");
         assert_eq!(parsed["pinned"], true);
+        assert_eq!(parsed["switched"], true);
     }
 
     #[test]
@@ -458,6 +464,7 @@ mod tests {
             trace_id: "abc123".to_string(),
             session_id: None,
             pinned: false,
+            switched: false,
         };
         let json = serde_json::to_string(&response).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -465,5 +472,6 @@ mod tests {
         assert!(parsed["route"].is_null());
         assert!(parsed.get("session_id").is_none());
         assert_eq!(parsed["pinned"], false);
+        assert_eq!(parsed["switched"], false);
     }
 }

--- a/docs/routing-api.md
+++ b/docs/routing-api.md
@@ -153,7 +153,8 @@ Response when pinned:
   "route": "code generation",
   "trace_id": "...",
   "session_id": "a1b2c3d4-5678-...",
-  "pinned": true
+  "pinned": true,
+  "switched": false
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `switched` boolean to the routing decision API response (`/routing/v1/chat/completions`), parallel to the existing `pinned` field.

- `pinned` — warm session cache inferred at decision time (maps to "% requests held" in Insights)
- `switched` — routing budget allowed the router's model pick when a switch cost was evaluated (`plano.switch.decision=allowed`; maps to "% requests switched" in Insights)

The value mirrors the `plano.switch.decision` span attribute: `true` when a switch cost was computed and the router's candidate was honored, `false` when the warm anchor was retained or no switch evaluation occurred.

## Testing
- `cargo test --lib -p brightstaff` (205 passed)
- `cargo clippy -p brightstaff -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://digitalocean.slack.com/archives/C0BEDCC09NG/p1787005607273709?thread_ts=1787005607.273709&cid=C0BEDCC09NG)

<div><a href="https://cursor.com/agents/bc-87aa0c86-8ae0-586a-b42c-d303e85f35cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87aa0c86-8ae0-586a-b42c-d303e85f35cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

