### PR TITLE
fix(docker): clear Trivy HIGH findings from util-linux and pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,8 @@ jobs:
             ${{ env.PLANO_DOCKER_IMAGE }}
             ${{ env.DOCKER_IMAGE }}:0.4.34
             ${{ env.DOCKER_IMAGE }}:latest
+          build-args: |
+            DEBIAN_SECURITY_ASOF=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,14 @@ FROM docker.io/envoyproxy/envoy:${ENVOY_VERSION} AS envoy
 
 FROM python:3.14-slim AS arch
 
+# Bump (or pass --build-arg) so layer cache does not pin stale Debian security packages.
+ARG DEBIAN_SECURITY_ASOF=2026-08-18
+
 # Install runtime deps first, then upgrade — so security patches also land on
 # packages pulled in transitively by the install, not just those already present
-# in the base image.
+# in the base image (util-linux CVE-2026-53615 → 2.41.5-0+deb13u1).
 RUN set -eux; \
+  echo "debian security as of ${DEBIAN_SECURITY_ASOF}"; \
   apt-get update; \
   apt-get install -y --no-install-recommends gettext-base procps; \
   apt-get upgrade -y; \
@@ -92,5 +96,11 @@ RUN mkdir -p /var/log/supervisor && \
     touch /var/log/envoy.log /var/log/supervisor/supervisord.log \
           /var/log/access_ingress.log /var/log/access_ingress_prompt.log \
           /var/log/access_internal.log /var/log/access_llm.log /var/log/access_agent.log
+
+# Runtime uses uv + installed planoai, not pip. Dropping pip also clears Trivy HIGH
+# findings from its vendored msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools
+# 70.3.0 (CVE-2025-47273 / pip vendor.txt).
+RUN pip uninstall -y setuptools wheel pip && \
+    rm -rf /usr/local/lib/python*/ensurepip
 
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
## Summary
- Rebuild the Debian apt layer on every CI scan so `util-linux` picks up `2.41.5-0+deb13u1` (CVE-2026-53615) instead of a cached `2.41-5`.
- Uninstall pip after image install so Trivy no longer reports pip's vendored msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0 (CVE-2025-47273). Runtime uses uv + planoai, not pip.

## Test plan
- [ ] Confirm CI `security-scan` reports 0 HIGH/CRITICAL findings
- [ ] Confirm the image still starts (`supervisord` → config generator via `uv run` → envoy/brightstaff)