### PR TITLE
Remove +60s GC slack from session cache TTL

### DIFF
--- a/crates/brightstaff/src/handlers/llm/session_router.rs
+++ b/crates/brightstaff/src/handlers/llm/session_router.rs
@@ -215,10 +215,6 @@ pub async fn reuse_prior_decision(
     })
 }
 
-/// Extra memory retention beyond the warmth window, so a still-warm binding is never
-/// GC'd out from under the router before it could plausibly go cold.
-const GC_SLACK: Duration = Duration::from_secs(60);
-
 /// Stable request facts the router reasons about. Independent of the transport (full
 /// proxy vs. decision endpoint) so both paths route identically.
 pub struct RouteFacts<'a> {
@@ -340,7 +336,7 @@ pub async fn route(
     facts: RouteFacts<'_>,
 ) -> RouteDecision {
     let now = SystemTime::now();
-    let candidate_gc_ttl = warmth_window(&capability_for_model(facts.candidate_model)) + GC_SLACK;
+    let candidate_gc_ttl = warmth_window(&capability_for_model(facts.candidate_model));
 
     // No session to anchor to: honor the candidate, persist nothing.
     let Some(session_id) = facts.session_id else {
@@ -573,7 +569,7 @@ pub async fn route(
     } else {
         existing.as_ref().map(|b| b.cached_tokens).unwrap_or(0)
     };
-    let gc_ttl = warmth_window(&capability_for_model(&model)) + GC_SLACK;
+    let gc_ttl = warmth_window(&capability_for_model(&model));
 
     // Route history: a drifted prefix invalidates every model's cache, so start fresh;
     // otherwise carry it forward. Record this turn's dispatched model (refined with the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes the `GC_SLACK` constant (`Duration::from_secs(60)`) that padded a session binding's cache-store TTL beyond the provider's cache warmth window (e.g. Anthropic's 5-minute idle window). The binding's storage lifetime in the session cache now matches the warmth window exactly instead of `warmth_window + 60s`.

## Why

"% requests held for cache" was measured higher than "% requests cached", and part of the discrepancy traces back to Plano holding sessions in the cache store slightly longer than the provider's effective cache TTL. This removes that extra 60s buffer so Plano's held/cached bookkeeping stays tightly in sync with the actual provider cache window.

Note: this only affects how long the binding is retained in the session cache store (Redis/memory) for GC purposes — it never affected the actual warm/cold routing decision, which already used the raw `idle_ttl`/`hard_ttl`/`extended_ttl` windows.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --lib` (all 235 tests pass, including the `session_router` warmth/GC suite)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://digitalocean.slack.com/archives/C0BEDCC09NG/p1787006573437309?thread_ts=1787006573.437309&cid=C0BEDCC09NG)

<div><a href="https://cursor.com/agents/bc-3e27900f-4a59-551b-92a1-1fa406cb4ead?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e27900f-4a59-551b-92a1-1fa406cb4ead&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

